### PR TITLE
ci: migrate release.yml and push-feature.yml to pnpm and the current template

### DIFF
--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -12,8 +12,6 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
-    env:
-      COREPACK_INTEGRITY_KEYS: 0
     name: The build process
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -22,34 +20,34 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Stages the pushed branch
-        uses: actions/checkout@v4
-      - name: Pre-prepare the Node.js version ${{ matrix.node-version }} environment
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v7
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
         with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install the latest corepack explicitly
-        run: npm install --force -g corepack@latest
-      - name: Enable the corepack
-        run: corepack enable
-      - name: Post-prepare the Node.js version ${{ matrix.node-version }} environment
-        uses: actions/setup-node@v4
+          run_install: false
+      - name: Prepare the Node.js version ${{ matrix.node-version }} environment
+        uses: actions/setup-node@v6
         with:
           cache: ${{ !env.ACT && 'pnpm' || '' }}
           node-version: ${{ matrix.node-version }}
       - env:
           HUSKY: 0
         name: Install the dependencies
-        run: pnpm i --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build
+      - name: Lint
+        run: pnpm run lint
       - name: Run the tests
         run: pnpm run test
+      - name: Pack
+        run: pnpm pack
     strategy:
       matrix:
         node-version:
-          - 20.x
           - 22.x
           - 24.x
+          - 26.x
         platform:
           - os: ubuntu-latest
             shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,18 @@ jobs:
       INVALID_DUMMY_TOKEN: invalid-token
     steps:
       - name: Stages the pushed branch
-        uses: actions/checkout@v3
-      - name: Prepare the Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v7
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
         with:
-          cache: ${{ !env.ACT && 'npm' || '' }}
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
           node-version-file: .node-version
-      - name: set npm config
-        run: npm config set unsafe-perm true
       - name: Resolve the dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
       - name: Build and release for NPM
         uses: JS-DevTools/npm-publish@v2
         with:


### PR DESCRIPTION
## Summary

Partial pass on #30 -- the items that do not depend on the branch rename (#28, still open):

- `release.yml`: `npm ci` -> `pnpm install --frozen-lockfile` via `pnpm/action-setup@v6`; drops the obsolete `npm config set unsafe-perm true` step and the stale `actions/checkout@v3` / `actions/setup-node@v3` pins.
- `push-feature.yml`: `actions/checkout@v7`, `pnpm/action-setup@v6`, `actions/setup-node@v6`, and the `22.x/24.x/26.x` matrix (20.x dropped, matching #27's `engines.node` floor). Replaces the manual "install corepack, enable corepack" steps and the `COREPACK_INTEGRITY_KEYS: 0` workaround with `pnpm/action-setup@v6`, which does not go through corepack's own signature-verification path. Adds `lint` and `pnpm pack` steps so the job actually runs lint, build, test, and pack.

**Not in this PR** (items 4-5 of #30, both need #28's rename first): renaming `push-master.yml` to match the eventual default branch, and purging remaining `master` references from `.github/`, `README.md`, and `.vscode/settings.json`.

## Verification

- `pnpm run lint`, `pnpm run build`, `pnpm run test`, `pnpm pack` all exit `0` locally
- `actionlint` on both changed workflow files: clean
- Expect this PR's own CI run to confirm the Node 20.x jobs are gone and 22.x/24.x/26.x are green -- the direct proof that the matrix fix landed

Refs #30

## Notes

Claimed under a direct operator instruction to bring #30 forward as far as possible while #28 is still open (normally A3's dependency check would filter this issue out). #30 stays open after this merges; see the issue for the remaining-scope breakdown.