### PR TITLE
chore: rename push-master.yml and purge remaining master references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🇬🇧 Read the contribution guide first
-    url: https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.md
+    url: https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md
     about: Please read this before filing an issue.
   - name: 🇯🇵 投稿の前に下記のドキュメントを一読ください
-    url: https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.ja.md
+    url: https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md
     about: Issueを立てる前にお読みください。
   - name: 🇨🇳 首先，阅读以下文档
-    url: https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.zh.md
+    url: https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
     about: 在提交问题之前请阅读此文档。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 <!--
 🇬🇧 At first, read the following documents:
-https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.md
+https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md
 
 🇯🇵 投稿の前に下記のドキュメントを一読ください:
-https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.ja.md
+https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md
 
 🇨🇳 首先，阅读以下文档:
-https://github.com/kurone-kito/jsonresume-types/blob/master/.github/CONTRIBUTING.zh.md
+https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
 -->

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,16 +1,16 @@
-name: The CI workflow on merge as a master branch
-run-name: Merged the master branch by @${{ github.actor }}
+name: The CI workflow on merge as a main branch
+run-name: Merged the main branch by @${{ github.actor }}
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
     branches:
-      - master
+      - main
 permissions:
   contents: write
 jobs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
     "**/.husky*": true,
     "**/node_modules/**/*": true
   },
-  "git.branchProtection": ["master"],
+  "git.branchProtection": ["main"],
   "search.exclude": {
     "**/*.d.ts": true,
     "**/.husky*": true,


### PR DESCRIPTION
## Summary

Finishes #30 now that #28 renamed the default branch to `main`:

- `push-master.yml` -> `push-main.yml`, retargeting its `push`/`pull_request` branch filters at `main` (was `master`)
- `.github/ISSUE_TEMPLATE/config.yml` and `.github/pull_request_template.md`: `blob/master/...` links -> `blob/main/...`
- `.vscode/settings.json`: `git.branchProtection` -> `["main"]`

`grep -rn 'master' .github/ README.md .vscode/` now reports no matches.

## Verification

- `pnpm run lint`, `pnpm run build`, `pnpm run test`, `pnpm pack` all exit `0`
- `actionlint` on the renamed workflow: clean except one pre-existing, unrelated finding noted below

## Notes

- `actionlint` flags `release-drafter/release-drafter@v5` (unchanged by this PR) as using a deprecated Actions runner; latest is `v7.7.0`. Out of this issue's scope (which says to keep the release-drafter job as-is), leaving as a follow-up rather than folding an unrelated dependency bump into this commit.
- Closes #30

Refs #38 (IDD adoption roadmap), #31 (this roadmap)