### PR TITLE
feat(idd): install the issue-authoring companion skill

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: issue-authoring
+description: Draft or refine IDD-ready GitHub issues, roadmap issues, and sub-issues before the normal IDD execution loop begins. Use when a request is too large or ambiguous for one reviewable change, when work needs decomposition or dependency encoding, or when the user asks for issue drafting, roadmap planning, or parallelizable task breakdown.
+---
+
+# Issue Authoring
+
+Use this skill to prepare issue-ready work before execution starts.
+Keep the skill concise and treat the repository docs as the canonical
+source for the full contract and schema.
+The canonical source bundle lives in this repository; install copies in
+the agent-specific skill directory your runtime reads.
+
+## Stable Phases
+
+Use two stable phases:
+
+1. **Intake and Clarification** — inspect relevant context, identify
+   ambiguity, run a secondary critique or explicit self-critique, and
+   ask only the questions that block safe issue drafting. Keep
+   clarification bounded; use the repository-local
+   `issueAuthoring.maxClarificationRounds` value when available,
+   otherwise default to 3 rounds. **Under-clarification stop rule**: if,
+   after bounded clarification, you still cannot name the concrete
+   surface to edit or an objective verification for a candidate task,
+   route it to `needs-decision` or ask — do not publish a
+   confidently-vague `ready` issue. Reliability over speed.
+2. **Decompose and Draft** — restate the request in implementation
+   terms, split it into atomic tasks, classify readiness, reuse existing
+   issues when safe, and draft the smallest issue shape that preserves
+   dependencies and reviewability.
+
+Preserve low-readiness work in stable buckets: ready, deferred,
+needs-decision, blocked-by-human, and out-of-scope.
+
+## Workflow
+
+1. Read the bundled contract in
+   [references/contract.md](references/contract.md).
+2. Reuse or extend an existing issue before creating a new one — but
+   never edit the body of an actively-claimed or open-PR issue (its
+   claimed agent will not pick the change up); cover it with a follow-up
+   issue instead. See the contract's claim-state precondition.
+3. Choose the smallest safe output shape:
+   - orphan issue for one ready autonomous task only when the target
+     repository discovers orphans (`issue-scope: roadmap-first`, the
+     default, via the orphan fallback, or `orphan-first`) and any
+     configured `orphan-first-policy` approval step can be completed
+     after drafting
+   - roadmap plus sub-issues for multi-task or multi-session work
+   - stable non-ready buckets for deferred, needs-decision,
+     blocked-by-human, or out-of-scope work
+4. **Prefix-first**: resolve the target repository's marker prefix
+   before emitting any authoring marker — `roadmap-id`, `blocked-by`,
+   `autopilot-suitability`, or `effort`. Use the prefix documented by
+   the target repository's onboarding or IDD docs, and ask the user
+   instead of guessing when the prefix is not discoverable. Never
+   default to this source repository's `idd-skill` prefix in an
+   installed bundle.
+5. Keep dependencies machine-readable and minimal:
+   - roadmap identity via
+     `<!-- <marker-prefix>-roadmap-id: ... -->`
+   - active child issues via roadmap task-list links
+   - issue-to-issue dependencies via `Blocked by #NNN`
+   - sequential roadmap dependencies via
+     `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+     roadmap
+     must close first
+   - keep independent sibling work in roadmap task lists unless a true
+     correctness, availability, or ordering constraint requires a
+     dependency edge
+6. Before publishing a ready orphan, roadmap, or child body, run the
+   `audit-authored-issue` linter against it as the mechanical
+   pre-publish gate — see
+   [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
+   in the bundled contract, including the manual fallback for
+   `instructions-only` installs with no helper runtime. Resolve every
+   reported failure before treating the issue as ready.
+7. When the user explicitly authorizes publication, manage the authoring
+   label for each created or updated issue:
+   - resolve `issueAuthoring.authoringLabelName`, defaulting to
+     `status:authoring`
+   - create the label with `gh label create` before first use when the
+     target repository does not already have it
+   - treat label creation or application failure as a publishing blocker
+   - apply the label before updating an existing issue
+   - create new issues with the label when supported, or apply the label
+     immediately after creation
+   - if post-create label application fails, close the created issue
+     before stopping; deletion needs admin permission the authoring
+     agent typically lacks (and `docs/permissions.md` forbids for normal
+     IDD), so it is not the default path
+   - remove the label from all published issues only after the full set is
+     published, the user confirms the result, and the user explicitly
+     requests release from the authoring hold for IDD execution
+   - leave the label in place if publishing is interrupted before release
+8. Stop at the approval boundary. Drafting issues does not authorize
+   publishing them or starting the IDD execution loop unless the user
+   explicitly asked for that.
+
+## Reference Routing
+
+- For the bundled contract, output schemas, and discoverability guard:
+  read [references/contract.md](references/contract.md).
+- For the bundled boundary between pre-approval drafting and the IDD
+  execution loop: read
+  [references/workflow-boundary.md](references/workflow-boundary.md).
+- For concrete drafting patterns and example prompts: read
+  [references/draft-patterns.md](references/draft-patterns.md).
+- When editing this bundle inside the source repository, keep the
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
+
+## Output Checklist
+
+- Preserve low-readiness work in stable buckets instead of dropping it.
+- Keep acceptance criteria explicitly verifiable.
+- Keep human-dependent setup, review, and approval work isolated from
+  ready execution issues whenever possible.
+- Link every active child issue from its roadmap body.
+- Justify each dependency edge and keep independent sibling work as
+  roadmap task-list entries.
+- Record reuse or extension decisions when the skill does not create a
+  new issue.
+- Avoid widening drafting output beyond the user request without saying
+  so.
+- Run the `audit-authored-issue` linter (or its manual fallback in
+  `instructions-only` installs) against every drafted ready body and
+  resolve every reported failure before publishing.
+- Name a concrete surface to edit and an objective verification for
+  every `ready` candidate; route anything else to `needs-decision` or
+  ask instead of guessing (the under-clarification stop rule).
+- Resolve the target repository's marker prefix before emitting any
+  authoring marker; never assume this source repository's `idd-skill`
+  prefix in an installed bundle (the prefix-first rule).

--- a/.claude/skills/issue-authoring/agents/openai.yaml
+++ b/.claude/skills/issue-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Authoring"
+  short_description: "Draft IDD-ready issues and roadmaps"
+  default_prompt: "Use $issue-authoring to draft an IDD-ready issue set for this request."

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1,0 +1,847 @@
+# Bundled Issue Authoring Contract
+
+This file keeps the `issue-authoring` bundle usable when it is installed
+or copied outside this repository root. It mirrors the canonical
+contract in `docs/issue-authoring-skill.md`.
+
+## Target marker prefix
+
+**Prefix-first**: resolve the target repository's hidden marker prefix
+before emitting _any_ authoring marker — `roadmap-id`, `blocked-by`,
+`autopilot-suitability`, or `effort`. Resolve it once, up front, not as
+an afterthought once a marker is already half-drafted.
+
+- Use the prefix documented by the target repository's onboarding or
+  IDD instructions.
+- In this source repository the prefix is `idd-skill`, but installed
+  bundles must not assume that value elsewhere. Never default to
+  `idd-skill` in an installed bundle; use it only when the target
+  repository actually configured that value.
+- If the prefix is not discoverable from the repository docs or user
+  context, stop and ask instead of emitting a guessed marker.
+
+## Trigger policy
+
+Use this bundle when direct implementation would skip the issue hygiene
+that the IDD execution loop depends on.
+
+Invoke it when one or more of the following are true:
+
+- the request is too large or ambiguous for one reviewable change
+- the likely solution needs decomposition into multiple atomic tasks
+- dependencies or execution order must be made explicit before work can
+  start safely
+- the user wants a roadmap, issue breakdown, or parallelizable work
+  plan
+
+Skip it when all of the following are true:
+
+- the task fits one reviewable change
+- verification is already clear
+- no roadmap, dependency marker, or issue split is needed
+- the user did not ask for issue drafting first
+
+## Stable phases
+
+The bundle uses two stable phases. These names mirror the canonical
+contract and should stay stable for copied bundles.
+
+### 1. Intake and Clarification
+
+In this phase, the agent:
+
+- inspects the relevant code, docs, and existing issues
+- identifies assumptions and ambiguity that affect issue quality
+- runs a secondary critique pass before drafting
+- asks the user only the questions that block safe issue drafting
+
+The critique pass is agent-neutral: use a subagent or rubber-duck
+reviewer when available, otherwise run an explicit self-critique
+locally. Clarification must be bounded; use the repository-local
+`issueAuthoring.maxClarificationRounds` value when available,
+otherwise default to 3 rounds. If safe drafting is still impossible
+after that, stop and report the remaining blockers instead of looping
+indefinitely.
+
+**Under-clarification stop rule.** If, after bounded clarification, you
+still cannot name the concrete surface to edit or an objective
+verification for a candidate task, route it to `needs-decision` or ask
+— do not publish a confidently-vague `ready` issue. Reliability over
+speed. This is distinct from the "Under-specified" specificity band
+below: that band judges an already-drafted body's wording, while this
+rule stops publication earlier, during Intake, before a body is even
+drafted.
+
+### 2. Decompose and Draft
+
+In this phase, the agent:
+
+- restates the clarified request in implementation-facing terms
+- splits work into atomic tasks
+- checks whether each task is suitable for autonomous execution
+- reuses or extends existing issues before creating new ones
+- drafts orphan issues, roadmap packages, sub-issues, or non-ready
+  buckets as appropriate
+
+## Readiness buckets
+
+Do not silently drop low-confidence or low-readiness work. Route each
+candidate task into one stable bucket:
+
+- **ready**: passes limited scope, clear verification, and autonomous
+  completion
+- **deferred**: plausible, but priority, timing, or decomposition is not
+  strong enough for execution
+- **needs-decision**: depends on a product, policy, or design choice
+- **blocked-by-human**: waits on a person, credential, asset, or outside
+  system
+- **out-of-scope**: does not belong in the repository or skill scope
+
+## Specificity target
+
+Issue drafting should aim for a level of specificity where a
+middle-tier cloud model can implement the task without drifting. This
+is a practical drafting heuristic, not a hard model requirement. The
+goal is to avoid both hidden assumptions that only a top-tier model can
+infer and step-by-step runbooks that cost too much to author.
+
+### Three specificity bands
+
+| Band                | Practical signal                                                                                                          | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class                                                           | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class can implement the issue without drifting                                                  | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+
+The capability tiers above are practical heuristics, not a fixed
+compatibility matrix or runtime requirement.
+
+### How the specificity target interacts with readiness
+
+This heuristic does not replace the IDD execution axes:
+
+- **Limited scope** still decides whether the work fits one issue or
+  needs a roadmap.
+- **Clear verification** still decides whether success is objectively
+  checkable.
+- **Autonomous completion** still decides whether the task can finish
+  without outside coordination.
+
+An issue can be specific yet still fail A4 or A4.5 because it is too
+broad, not verifiable, or blocked on a human decision. Conversely, an
+issue that passes those gates can still be under-specified if it leaves
+too much implementation shape implicit. The drafting target is therefore
+"ready and stable for a middle-tier model," not "maximally detailed."
+
+## Executability gate for code spec-units
+
+For a **code spec-unit** — a drafted unit whose acceptance criteria are
+objectively executable (a script, function, or test the drafted issue
+itself specifies) — an authoring session can validate the draft before
+publishing by building a throwaway reference implementation against its
+own stated acceptance check and accepting the draft only if that
+reference implementation passes. This reuses the downstream execution
+loop as an upstream ground-truth gate: it catches drafts whose
+acceptance criteria are internally inconsistent, non-trivially
+unsatisfiable, or otherwise not actually implementable, before a
+downstream executor ever claims the issue. The reference implementation
+is a discarded validation probe, never published — it does not cross the
+Publication boundary below; only the drafted issue itself is published,
+and building the probe does not start the IDD execution loop.
+
+This is a **recommended practice for repositories or domains where a
+drafted code spec-unit has an objectively executable acceptance
+check**, not a change to this repository's own mechanical
+`bin/idd-audit-authored-issue.mjs` checks or a new requirement on this
+repository's own issue-authoring practice — most of this repository's
+issues are multi-file engineering changes without a single executable
+acceptance check to validate against.
+
+- **Weak-model semantic self-review stays advisory.** When a weak
+  authoring model reviews its own draft for semantic quality, treat the
+  verdict as advisory only, never a hard veto on publishing — mirroring
+  the narrow-question guidance for weak-model judgment calls in
+  `docs/idd-workflow.md`'s Weak-model guardrails section.
+- **Decompose and draft want different model traits.** Decomposition
+  (judgment about scope and structure) tolerates a verbose reasoning
+  model; the structured draft step (emitting the exact spec/acceptance-
+  criteria block) is more reliable on a leaner, more literal model,
+  whose chain-of-thought does not compete with the drafted block for
+  token budget. Pick the model per sub-task, not per pipeline, when both
+  are available.
+- **Redraft and re-decomposition are limited rescue mechanisms, not
+  reliable fixes.** A bounded redraft loop tends to re-roll rather than
+  converge, because a weak author regenerates rather than incrementally
+  fixes. Re-decomposing a repeatedly-failing unit is usually low-value
+  too: most authoring failures are hard-but-atomic rather than
+  over-broad, and splitting a hard-but-atomic unit tends to produce
+  incoherent sub-units that do not recompose. Treat a code spec-unit
+  that repeatedly fails this gate as a candidate for `needs-decision` or
+  human/stronger-model authoring instead of looping indefinitely.
+
+## Reuse-first issue policy
+
+Before creating any new issue, check whether the work already has a
+suitable home.
+
+**Claim-state precondition (check this first).** Before reusing or
+extending _any_ existing issue, determine whether it has an **active
+claim** (its latest valid `claimed-by` comment is newer than the
+configured `claim-stale-age`; distributed default 24 h) or an **open
+PR**, or is otherwise actively executing. If so, you **MUST NOT edit its
+body**: the working agent snapshots the issue body into its B2 plan and
+treats that plan as authoritative — it never re-reads the body, so a
+post-claim body edit is silently lost and becomes an implementation gap.
+You **may** add a separate **comment** (never an edit or append to the
+body), but **must not** rely on the claimed agent acting on it. Cover
+the intended change with a **follow-up issue** (or a roadmap track around
+it), and you **SHOULD** post a cross-reference comment on the claimed
+issue linking the follow-up. Stale or reclaimable claims (latest
+`claimed-by` older than `claim-stale-age`) are exempt — the next claimer
+re-reads the latest body, so editing them is safe.
+
+Then apply these checks in order:
+
+1. If an existing open issue already matches the task and only lacks the
+   new schema details, extend that issue instead of cloning it.
+2. If an existing open roadmap already owns the initiative, add or
+   refine task-list entries there instead of creating a competing
+   umbrella.
+3. If an existing issue is close but too broad, split follow-up work
+   out of it rather than widening the original issue further. When the
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
+4. If an existing issue has an **active claim**, an open PR, or is
+   otherwise being actively executed, do **not** edit its body or
+   repurpose it (see the claim-state precondition, which exempts
+   stale/reclaimable claims); create a follow-up issue or extend the
+   roadmap around it instead.
+5. Create a brand-new issue only when no existing issue can absorb the
+   work without harming ownership, clarity, or reviewability.
+
+Report when the bundle reuses, extends, or declines to reuse an issue
+so a later session can follow the reasoning.
+
+**Recent-window scan for just-discovered problems.** The checks above
+assume the work already has a candidate home to reuse or extend. When
+instead authoring an ad hoc issue for a problem **just discovered**
+during the current session — a build-breaking regression noticed
+mid-session, for example, rather than a task drafted from an existing
+backlog — run a recent-window duplicate scan immediately before
+publishing: list the newest issues regardless of state and check
+whether a concurrent session already authored the same problem.
+
+```sh
+gh issue list --repo <owner>/<repo> --state all --limit 20
+# or, scoped to a recency window:
+gh issue list --repo <owner>/<repo> --state all --search "created:>=<YYYY-MM-DD>"
+```
+
+A hit routes back into the checks above: extend the discovered issue
+instead of publishing a duplicate. When the race slips past this scan
+anyway (near-simultaneous discovery), the outcome is **anticipated and
+self-resolving, not a coordination failure**: both sessions proceed
+independently through their own claim and implementation cycle;
+whichever PR merges first wins; the other session manually verifies
+the fix already landed on the default branch, then closes its own
+issue and (unmerged) PR as superseded, citing the verifying evidence.
+This is the same manual verify-then-close judgment call the execution
+loop's B2.0 supersession re-check (`idd-work.instructions.md`) applies
+after claim — this scan only adds an earlier, pre-publish checkpoint.
+A fast enough race can still surface even after B2.0; when it does, it
+resolves the same way.
+
+## Output chooser
+
+Choose the smallest safe output shape:
+
+- **Orphan issue**: one autonomous task can finish the work, no
+  roadmap-level coordination is needed, and the target repository
+  discovers orphans — i.e. `issue-scope` is `roadmap-first` (the
+  default; orphans are picked up as the fallback when no roadmap work is
+  startable) or `orphan-first` (orphans first). If the repository uses
+  `orphan-first-policy: maintainer-approved`, surface the required
+  post-publication maintainer approval step. If the repository sets
+  `issue-scope: roadmap` (roadmap-only) or disables public orphan-first
+  discovery with `orphan-first-policy: public-disabled`, surface that
+  constraint and prefer a roadmap package instead.
+- **Roadmap plus sub-issues**: the request needs visible sequencing,
+  parallel tracks, multiple ready issues, or multi-session handoff.
+- **Stable non-ready buckets**: some work is deferred, blocked by a
+  human, waiting on a decision, or outside the repository scope.
+
+When the repository keeps the broader issue-author approval gate,
+surface the same post-publication approval step for orphan issues,
+roadmaps, and sub-issues whenever the issue author is not
+self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is satisfied,
+route the draft to the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+## Human-dependency isolation
+
+Treat unresolved human dependency as a side effect that should be
+isolated away from ready execution issues whenever possible.
+
+- **Front-load** human-dependent work when coding cannot start safely
+  until a person provides a decision, credential, permission,
+  maintainer-only action, external setup, or policy choice, or until an
+  unavailable system becomes usable again.
+- **Back-load** human-dependent work when the remaining dependency is
+  subjective review, publication choice, optional polish, or another
+  post-implementation judgment that should not block an otherwise
+  autonomous core change.
+- Keep the central execution issue as close as possible to a pure
+  autonomous unit: clear repository-local scope, no hidden human handoff
+  in the implementation steps or acceptance criteria, and objective
+  verification.
+- Preserve unavoidable human-dependent work in an explicit stable
+  bucket, dependency edge, or approval-needed hold rather than mixing it
+  into a ready issue.
+- Route unresolved choices to `needs-decision`, route waiting on people,
+  credentials, maintainer-only actions, or unavailable systems to
+  `blocked-by-human`, use `deferred` when timing or decomposition is not
+  strong enough yet, and keep approval-gated ready work in the
+  approval-needed hold instead of the normal ready-to-start set.
+- If a task cannot be expressed without unresolved human coordination in
+  the middle of implementation, it is not yet `ready`.
+
+This principle complements the execution axes rather than replacing
+them: it is a practical way to protect autonomous completion and clear
+verification during issue drafting.
+
+## Hidden human-dependency validation
+
+Before publishing a `ready` issue, run a short pre-publication check for
+hidden human dependency. Treat this as a routing aid, not a rigid
+wording linter: the question is whether the work still depends on
+unresolved human action, not whether the draft used one forbidden
+phrase.
+
+Ask these checks:
+
+1. Does implementation require credentials, external access, hardware,
+   or infrastructure that the executing agent cannot already reach? If
+   yes, route the work to `blocked-by-human` unless that dependency can
+   be front-loaded into a separate prerequisite issue.
+2. Does any implementation step or acceptance criterion depend on a
+   product, policy, or design decision that has not been made? If yes,
+   route the work to `needs-decision`.
+3. Do the acceptance criteria require subjective human approval instead
+   of objective verification? If yes, rewrite the ready issue around
+   measurable checks and back-load the optional review or publication
+   judgment.
+4. Does a roadmap narrative hide human-dependent work inside prose while
+   the visible task list presents the item as execution-ready? If yes,
+   preserve that work in an explicit stable bucket, approval-needed
+   hold, or blocking issue instead of burying it in the narrative.
+5. Is any dependency marker being used only to group related work or
+   express preference order? If yes, remove the fake blocker and use
+   task-list structure or sequencing notes instead. Keep dependency
+   edges only for true start blockers.
+
+Normal post-implementation code review, merge approval, or publication
+choice does not by itself make an otherwise autonomous issue non-ready.
+The ready issue should still carry its own objective verification even
+when a human will look at the result afterward.
+
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
+
+## Dependency minimization
+
+Encode a dependency edge only when it reflects a true correctness,
+availability, or ordering constraint.
+
+- keep independent sibling tasks as roadmap task-list entries, with
+  short sequencing or parallelization notes when that helps reviewers or
+  later agents
+- use visible or sequential dependency markers only when the issue
+  cannot start safely until the dependency resolves
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
+
+When an issue keeps a dependency edge, justify each dependency edge in
+the surrounding issue body and confirm that the split still preserves
+natural cohesion.
+
+## Nested roadmap nodes
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. A nested roadmap
+is still a roadmap node, not a normal execution candidate.
+
+Authoring rules:
+
+- reference the nested roadmap from the parent roadmap task list instead
+  of hiding it in prose
+- give the nested roadmap its own roadmap marker and `## Tracks` section
+  that links the active child work it coordinates
+- treat the nested roadmap as a coordination/audit node for discovery
+  and roadmap audit; do not draft it as normal A3/A4/A5 execution work
+- use two-level or three-level nesting only when the intermediate
+  roadmap has its own active child work or handoff boundary
+- do not use `Blocked by #NNN` or
+  `<!-- <marker-prefix>-blocked-by: ... -->` only to group leaf issues
+  under an active nested roadmap; reserve those encodings for true
+  execution dependencies or sequential roadmap dependencies between
+  separate roadmaps
+
+Validation expectations:
+
+- each nested roadmap node is linked from its parent roadmap task list
+- each nested roadmap node links its own active child work from its body
+- cycles, duplicate references, and closed intermediate roadmaps with
+  hidden open descendants must be surfaced as validation failures or
+  explicit follow-up notes, not silently normalized away
+
+## Required dependency encoding
+
+- Roadmap identity via `<!-- <marker-prefix>-roadmap-id: ... -->`
+- Active child issues via roadmap task-list links
+- Issue-to-issue dependencies via `Blocked by #NNN`
+- Sequential roadmap dependencies via
+  `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+  roadmap
+  must close first
+
+## Required draft content
+
+### Orphan issue
+
+- title with a concise user-facing summary
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
+  see [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- no `<marker-prefix>-roadmap-id` marker
+- no `<marker-prefix>-blocked-by` marker
+- acceptance criteria are explicitly verifiable
+- the issue stays discoverable under the target repository's
+  `issue-scope` setting
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+### Roadmap issue
+
+- title that describes the umbrella initiative
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- every active child issue or nested roadmap node is referenced from the
+  roadmap body
+- the roadmap explains why multiple issues exist
+- sequencing and blocking are explicit
+- each dependency edge is justified and preserves natural cohesion
+- nested roadmap entries stay identifiable as coordination/audit nodes
+  instead of normal execution leaves
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+### Child issue under a roadmap
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- the issue is referenced from its parent roadmap task list
+- acceptance criteria are locally verifiable
+- any dependency marker is resolvable, intentionally chosen, and
+  justified
+- the issue can be claimed independently without absorbing sibling work
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+## A4.5 Suitability Gate Alignment
+
+When an issue is published and reaches the IDD discover phase, the A4.5
+pre-claim gate will evaluate it against seven suitability checks. The
+authoring skill should catch these issues before publishing:
+
+| Check                    | Authoring Bucket     | How to Prevent                                                                  |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------- |
+| Repository Fit (Check 1) | `out-of-scope`       | Ensure issue is scoped to this repository; escalate if it crosses boundaries    |
+| Coherence (Check 2)      | `ready` or escalated | Validate issue body against schema before publish                               |
+| Safety/trust (Check 3)   | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
+| Duplicates (Check 4)     | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
+| Actionability (Check 5)  | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
+| Autonomy (Check 6)       | `ready` or escalated | Ensure agent can complete without external coordination                         |
+| Verifiability (Check 7)  | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
+
+Pre-publish validation checklist:
+
+1. **Coherence**: Issue body is well-formed, title+description are
+   clear, intent is parseable
+2. **Safety**: No code injection, marker injection, or untrusted input
+   in issue body
+3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded
+   work
+4. **Human dependency isolation**: Ready issues do not hide unresolved
+   decisions, credentials, subjective approvals, or mid-implementation
+   human handoffs
+5. **Mechanical audit**: the drafted body passes the
+   `audit-authored-issue` linter for its declared shape (see
+   [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+If any check is uncertain, route the issue to `needs-decision` or
+`blocked-by-human` during drafting instead of publishing a
+marginally-ready issue.
+
+## Mechanical pre-publish gate
+
+Before publishing a drafted `ready` **orphan, roadmap, or child** body
+(the shapes the linter supports — not the non-ready buckets below,
+which are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime is
+available. It mechanically re-checks a subset of the structural rules
+this contract states in prose — the autopilot-suitability marker's
+exactly-one/coherent-value rule, the one-directional check that a
+suitability score of `1` carries the configured `blocked-by-human`
+label (it does not check the reverse: a non-`1` score paired with the
+label still passes), markerPrefix consistency across every authoring
+marker, the declared shape's required section headings, the
+roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
+agreement for the suitability and effort footers — so a weak model does
+not have to hold every rule in its head at once while drafting.
+
+The linter also emits one **advisory, warning-severity-only** finding
+(`prose-dependency`): it flags an issue/PR reference (`#<digits>` or a
+full GitHub issue/PR URL) that appears near coordination language (for
+example "before", "after", "once", "until", "predates", "gate"/"gated",
+"requires", "lands first") with no corresponding encoding for that
+reference as one of the three recognized forms: a `Blocked by #NNN`
+line, a `Depends on #NNN` line, or a task-list checkbox item
+(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
+`extractDependencyIssueNumbers` already recognize elsewhere in this
+contract. A task-list checkbox counts regardless of which heading it
+sits under, so a roadmap's own `## Tracks` membership list already
+satisfies this — it is not a separate "dependency-only" list. This
+catches the pattern this contract's own
+[Hidden human-dependency validation](#hidden-human-dependency-validation)
+check 4 warns about in prose — a hard precondition stated only in
+narrative text, not encoded as a real dependency marker. A full-URL
+reference is inherently local only when it actually names the current
+repository, since a cross-repo dependency cannot be encoded with these
+repository-local markers at all — flagging it would recommend an
+impossible fix. When the caller supplies the current `owner/repo`
+(`--current-repo`, defaulting to `$GITHUB_REPOSITORY` in CI), a
+full-URL reference naming a different repository is never flagged;
+without that context, a full-URL reference is still flagged by
+default (unchanged behavior) — unless its issue/PR number happens to
+already appear as a local `Blocked by` / `Depends on` / task-list
+marker elsewhere in the body, in which case it is treated as already
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for every nested child under a given parent, at any depth — not
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
+`prose-dependency` warning never flips `passed` to `false` and never
+changes the linter's exit code: it prompts the author to either
+convert the prose into a proper dependency marker or consciously
+confirm the reference is a mere breadcrumb.
+
+```sh
+node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
+  --marker-prefix <resolved-target-prefix> \
+  --body-file <path-to-drafted-body> [--label <label>]...
+```
+
+Or, for npx/package-manager profiles, the equivalent
+`idd-audit-authored-issue` command. Pass `--stdin` instead of
+`--body-file` when the drafted body is not yet written to disk.
+**Always pass `--marker-prefix`** with the prefix resolved under
+[Target marker prefix](#target-marker-prefix): without it, the linter
+falls back to reading `.github/idd/config.json` from the current
+working directory, and if that file is missing or unreadable — for
+example when running from an installed bundle without a local
+checkout of the target repository's config — it silently defaults to
+this source repository's own `idd-skill` prefix, which produces a
+false pass or fail against the wrong prefix instead of an error.
+
+**No helper runtime available (`instructions-only` profile).** The
+linter cannot run without Node.js and the vendored `scripts/`
+directory, and an `instructions-only` install is a first-class
+supported fallback, not a degraded one. Unavailability is never a
+waiver: manually re-verify the same checks listed above against this
+contract's prose and the [Draft schemas](#required-draft-content)
+before publishing.
+
+A `passed: false` report (or non-zero exit, or a failed manual
+re-verification) means the draft is not ready to publish yet,
+regardless of how complete the narrative reads — fix every reported
+finding and re-run before treating the issue as `ready`. The linter (or
+its manual equivalent) is a mechanical structural check, not a
+substitute for the judgment-based checks above (human-dependency
+isolation, codebase fidelity, reuse-first) — passing it is necessary,
+not sufficient, for `ready`.
+
+## Autopilot-suitability score
+
+> **Status.** Active contract. Authoring **emits** the score footer
+> and Discover **ranks and routes** candidates by it (roadmap #759,
+> fully merged). The score stays advisory: it never bypasses the
+> A4.5/A5 gates and is fail-safe on absence.
+
+Authored issues carry a persisted **autopilot-suitability score**
+from 1 to 5 (higher = more autopilot-suitable). It is the durable,
+graded form of the **Autonomous completion** execution axis: the
+author makes the judgment once, while context is fresh, so the
+Discover phase can rank and route candidates by a cheap read
+instead of re-deriving autonomy per candidate.
+
+| Score | Meaning                     | Typical signals                                                                                                          |
+| ----- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 5     | Autopilot-ideal             | Fully specified; deterministic verification (tests/lint/CI/mechanical); no external systems; no human judgment; isolated |
+| 4     | Strongly autopilot-suitable | Well-specified and verifiable; minor ambiguity resolvable from repo context; no external/human dependency                |
+| 3     | Borderline / mixed          | Autopilot can likely finish but with notable judgment, weaker verification, or review-attention risk                     |
+| 2     | Mostly human                | Agent may draft a partial result; completion needs human judgment, an asset, or review the agent cannot supply           |
+| 1     | Human-only                  | Interactive credentials, real deployment, subjective/design/product judgment, or external coordination                   |
+
+Scores below the configured discovery floor
+(`autopilotSuitability.floor`, default `3`) designate
+**human-oriented issues**: in autopilot runs Discover routes them
+to humans rather than autopilot.
+
+The score is recorded as a **footer at the end of the issue
+body** — a visible line paired with a hidden, prefix-aware
+machine marker, mirroring the `claimed-by` convention (visible
+note + HTML marker):
+
+```text
+---
+
+_Autopilot suitability: N / 5 -- higher is more autopilot-suitable;
+below the configured floor is human-oriented._
+
+<!-- {marker-prefix}-autopilot-suitability: N -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware via
+  `createMarkerRegex(markerPrefix, "autopilot-suitability")` exactly
+  as `roadmap-id` / `blocked-by` are. `N` is an integer 1-5. The
+  visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** This is body
+  content like `roadmap-id`; it must never be added to
+  `OPERATIONAL_MARKERS` in `scripts/protocol-helpers.mjs` or
+  subjected to F4 minimization.
+- **One source of truth.** A score of `1` must agree with
+  `status:blocked-by-human`; never publish a contradiction.
+- **Advisory, never a gate.** The score only ranks/routes
+  candidates. The A4.5 suitability gate and A5 claim safety checks
+  still run unchanged on whatever issue is selected; a high score
+  never bypasses a gate.
+- **Fail-safe on absence.** A missing, non-integer, or
+  out-of-range marker means "no score": Discover evaluates the
+  issue the normal way and never skips it. Pre-existing issues
+  with no score keep flowing.
+
+Backfill is opportunistic: when an existing open issue without a
+score footer is next edited by the authoring flow, add one. No
+bulk backfill of the existing backlog is required. The claim-state
+precondition still applies — never add the footer to the body of an
+actively-claimed or open-PR issue; defer it to a follow-up instead.
+
+## Effort hint
+
+Authored issues may also carry an **effort hint** — an author-time
+`S | M | L` size estimate, recorded once while context is fresh, that
+Discover consumes as a **soft selection tie-breaker** so autopilot tends
+to clear small issues first and leave large ones for a fresh session.
+Effort is distinct from the autopilot-suitability score: suitability
+captures _autonomy_ (can an agent finish unattended), while effort
+captures _size_ (a fully-autonomous issue can still be large).
+
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
+
+The hint is recorded as a **footer at the end of the issue body** — a
+visible line paired with a hidden, prefix-aware machine marker, beside
+the autopilot-suitability footer:
+
+```text
+---
+
+_Effort: S | M | L -- author-estimated size; a soft autopilot
+selection tie-breaker only._
+
+<!-- {marker-prefix}-effort: S|M|L -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware exactly
+  as `autopilot-suitability` is. `S | M | L` is upper-cased on parse.
+  The visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Soft tie-breaker, never a gate.** Effort only reorders candidates
+  **within** a single suitability-score band, after the score and
+  optional desync rules and **before** the lowest-issue-number tie-break.
+  It never skips, gates, crosses a score band, or bypasses the A4.5/A5
+  gates, and a large (`L`) issue stays fully claimable when it is the only
+  ready work.
+- **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
+  marker means "no effort hint": selection behaves exactly as it does
+  today (a missing hint sorts as the neutral middle, as-if `M`).
+  Pre-existing issues with no effort footer keep flowing.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
+
+## Publication boundary
+
+Drafting issues does not authorize publishing them or starting the IDD
+execution loop unless the user explicitly asked for that next step.

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -1,0 +1,598 @@
+# Draft Patterns
+
+Load this file after reading
+[`contract.md`](contract.md) when you need concrete examples or a quick
+chooser for output shapes.
+
+## Example triggers
+
+- "Break this request into IDD-ready issues before we implement
+  anything."
+- "Draft a roadmap for this feature and split the ready work."
+- "Turn this broad request into reviewable orphan issues."
+- "Check whether an existing issue should be extended instead of opening
+  a new one."
+
+## Output chooser
+
+Draft an orphan issue only when one autonomous task can finish the work
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
+maintainer-approved`, include a post-publication approval step after the
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
+`orphan-first-policy: public-disabled`, draft a roadmap package instead.
+
+If the repository keeps the broader secure-by-default issue-author
+approval gate, use the same post-publication approval note whenever the
+issue author will not be self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is
+satisfied, later discovery should treat the issue as part of the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+Draft a roadmap plus sub-issues when the request needs visible
+sequencing, parallel tracks, or multi-session handoff.
+
+Draft only stable non-ready buckets when the work still depends on a
+human decision, missing asset, or unclear verification.
+
+## Under-clarification stop rule
+
+Before drafting a `ready` issue, confirm you can name a concrete surface
+to edit and an objective verification for it. If, after bounded
+clarification, you still cannot, route the candidate to `needs-decision`
+or ask — do not publish a confidently-vague `ready` issue. Reliability
+over speed.
+
+This is an Intake-phase gate on your own confidence, not a wording
+judgment on an already-written draft — it is distinct from the
+"Under-specified" band in the next section, which assesses a body that
+has already been drafted.
+
+**Example**: "Improve the error handling in the API layer" fails this
+check — no concrete surface, no objective verification — even before
+you consider how detailed to write the body. Ask which endpoint or
+module, and what the observable failure mode is, or route the request
+to `needs-decision` instead of guessing at a plausible-sounding scope.
+
+## Specificity target
+
+Execution-ready issue drafts should land in a middle band:
+
+- **Under-specified**: a high-range model still has to infer the real
+  implementation shape because the issue names only a vague goal,
+  omits the likely surface to edit, or leaves verification too loose.
+- **Target range**: a solid mid-tier cloud model can hold a stable plan
+  without extra clarification. The issue points at the relevant
+  document, schema, or code surface, explains the constraint, and keeps
+  acceptance criteria verifiable without dictating every edit.
+- **Over-specified**: even a lightweight model could follow the issue as
+  a script because the body prescribes exact edit order, wording, or
+  implementation steps that reviewers do not need.
+
+If a draft feels like it needs a high-range model just to guess the intended
+change, it is still too vague. If it reads like line-by-line assembly
+instructions, it is too detailed.
+
+## Specificity checklist before publishing
+
+Before you publish a ready issue, confirm:
+
+- the title and background name the concrete artifact or surface that
+  should change
+- a mid-tier cloud model could choose a stable implementation direction
+  without hidden repository archaeology or a follow-up clarification loop
+- the acceptance criteria verify the outcome, not a step-by-step
+  implementation recipe
+- candidate files, examples, and notes act as cues rather than an
+  exhaustive script
+- removing one concrete detail would make the issue feel high-range-only,
+  while adding more detail would start turning it into a lightweight
+  model script
+
+## Mechanical pre-publish gate
+
+Before you publish a drafted **ready orphan, roadmap, or child** body
+(scoped to those ready shapes — non-ready buckets like
+`blocked-by-human` are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime
+is available. It mechanically catches shape and marker mistakes — a
+missing or duplicated autopilot-suitability footer, a wrong
+markerPrefix, a missing required heading for the declared shape, a
+malformed dependency marker — that a confident narrative can otherwise
+mask:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+**Always pass `--marker-prefix`** with the prefix resolved under
+[contract.md's Target marker prefix](contract.md#target-marker-prefix):
+without it, the linter falls back to reading
+`.github/idd/config.json` from the current working directory, and
+silently defaults to this source repository's own `idd-skill` prefix
+when that file is missing or unreadable — producing a false pass or
+fail against the wrong prefix instead of an error.
+
+Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
+instead of `--body-file` when the draft is not yet on disk, and
+`--label <name>` (repeatable) to pass proposed labels for the check
+that a suitability score of `1` carries the configured
+`blocked-by-human` label (default `status:blocked-by-human`; use
+`--config <path>` to point at a policy that overrides the label name —
+this check is also one-directional, it does not flag the reverse, a
+non-`1` score paired with the label). Fix every reported finding and
+re-run before publishing; a `passed: false` report means the draft is
+not ready yet, regardless of how complete the narrative reads.
+
+**No helper runtime available (`instructions-only` profile):** the
+linter cannot run. `instructions-only` is a first-class supported
+fallback, not a waiver — manually re-verify the same checks against
+[contract.md's Mechanical pre-publish gate](contract.md#mechanical-pre-publish-gate)
+before publishing instead.
+
+## Hidden human-dependency quick check
+
+Before you publish a `ready` issue, confirm:
+
+- the implementation does not still depend on unresolved credentials,
+  access, or unavailable infrastructure
+- unresolved product, policy, or design choices have been routed to
+  `needs-decision` instead of being buried in implementation steps
+- acceptance criteria use objective verification, while optional
+  post-implementation review stays optional
+- roadmap narrative does not hide human-dependent work that belongs in a
+  stable bucket or approval-needed hold
+- dependency markers represent true start blockers rather than grouping
+  related work
+
+## Codebase-fidelity quick check
+
+Before you publish a `ready` issue, confirm:
+
+- when the issue reuses an existing identifier or field name, the
+  specified value matches that name's established semantics in the
+  codebase — it does not overload a name with a new shape or source
+- values that are mutable at runtime are flagged to specify a live read
+  at the point of use rather than a one-time capture at construction
+
+## Example orphan issue
+
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional `## Candidate files`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+
+Use this shape when the work is narrow enough to pass the IDD viability
+gate on its own and the target repository can actually discover orphan
+issues (`issue-scope: roadmap-first`, the default, via the orphan
+fallback, or `orphan-first`). If the repository sets
+`issue-scope: roadmap` (roadmap-only), prefer a one-item roadmap package
+instead of publishing a standalone orphan issue.
+
+## Example roadmap package
+
+Roadmap issue:
+
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: ... -->` marker
+- an autopilot-suitability footer at the end of the body
+
+Child issue:
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body
+
+Keep ready child issues in the roadmap task list rather than grouping
+them with hidden dependency markers.
+
+## Nested roadmap chooser note
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. Keep the parent
+roadmap pointing to the nested roadmap, and keep the nested roadmap
+pointing to the leaf execution issues it coordinates.
+
+Parent roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #510 — backend track roadmap
+```
+
+Nested roadmap `#510` `## Tracks` excerpt:
+
+```md
+- [ ] #511 — define the backend contract
+- [ ] #512 — wire the contract into Discover
+```
+
+Treat `#510` as a coordination/audit node, not as a normal execution
+issue. Do not replace that relationship with `Blocked by #NNN` or
+`<!-- <marker-prefix>-blocked-by: ... -->` only to group the leaf
+issues under the parent roadmap.
+
+## Dependency minimization examples
+
+### Natural parallel decomposition
+
+Roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #401 — update the issue-authoring contract
+- [ ] #402 — add draft-pattern examples
+
+_Parallel note: #401 and #402 can proceed independently once the roadmap
+exists because neither task depends on the other's output._
+```
+
+This is the preferred shape for sibling tasks that can be reviewed and
+verified independently. The roadmap keeps both tasks visible in its task
+list, and the short note explains the safe parallelism without adding a
+fake `Blocked by` edge.
+
+### Artificial decomposition
+
+Bad serial chain:
+
+```md
+#401 — update the issue-authoring contract
+#402 — add draft-pattern examples
+
+Blocked by #401
+```
+
+This is over-serialized when `#402` can be reviewed and verified without
+waiting for `#401`. Do not create a serial chain just to make the order
+feel tidy.
+
+Bad split for parallelism:
+
+```md
+#410 — add one checklist bullet
+#411 — add one example paragraph
+#412 — add one anti-pattern sentence
+```
+
+This is an artificial split when the three edits form one natural,
+cohesive authoring change. Do not break a single reviewable task into
+multiple sibling issues only to widen parallel execution.
+
+### Finalize or verify track that asserts sibling-produced state
+
+Anti-pattern — prose sequencing only:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+
+_Runs after the wiring tracks #441-#445._
+```
+
+The hard `Blocked by #440` names only the build foundation, and the
+after-the-siblings ordering lives in prose. Once `#440` closes, Discover
+reports `#450` startable and A4.5 passes it (Actionability inspects the body,
+not completability) — but its acceptance criteria assert state that only the
+unmerged `#441`–`#445` produce, so claiming it means failing acceptance or
+doing the siblings' work.
+
+Correct — encode `Blocked by` on each sibling whose output the acceptance
+criteria depend on:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+Blocked by #441
+Blocked by #442
+Blocked by #443
+Blocked by #444
+Blocked by #445
+```
+
+Now Discover and A4.5 defer `#450` until every sibling merges, so it is
+claimed only when its acceptance criteria can actually pass.
+
+**Prefix-first**: resolve `<marker-prefix>` from the target repository's
+onboarding or IDD docs before emitting any of these markers —
+`roadmap-id`, `blocked-by`, `autopilot-suitability`, or `effort` — not
+just the dependency markers shown above. Never default to `idd-skill`
+in an installed bundle; use it only when the target repository actually
+configured that prefix.
+
+## Human-dependency isolation examples
+
+The examples below show how to move unavoidable human side effects to
+explicit boundaries rather than hiding them inside a ready execution
+issue. See [`contract.md`](contract.md) for the routing rules
+(`needs-decision`, `blocked-by-human`, `deferred`, approval-needed).
+
+### Front-loaded pattern
+
+Use this when coding cannot start safely until a person provides a
+decision, credential, permission, or external setup.
+
+**Bad (mixed)**: One execution issue that mixes implementation with an
+unresolved credential gap:
+
+```md
+## Background
+
+Add Stripe webhook support.
+
+## Proposed change
+
+Implement the `/api/webhooks/stripe` endpoint.
+
+## Acceptance criteria
+
+- Stripe webhook secret is configured in production.
+- Endpoint returns 200 for valid events.
+```
+
+This fails the IDD viability gate: the "Stripe webhook secret is
+configured in production" criterion requires a person to perform an
+action in an external system before the issue can be verified. The agent
+cannot autonomously confirm the outcome.
+
+**Good (front-loaded)**: Separate the human-dependent setup into its own
+issue, then write the autonomous implementation issue that depends on it.
+The `## Tracks` task list should contain only ready execution issues;
+route the non-ready blocker to a separate section or a stable non-ready
+bucket.
+
+Roadmap body excerpt:
+
+```md
+## Non-ready prerequisites
+
+- **[blocked-by-human]** #431 — obtain Stripe webhook secret for CI
+  _(must close before #432 can start)_
+
+## Tracks
+
+- [ ] #432 — implement /api/webhooks/stripe endpoint
+```
+
+`#431` — `blocked-by-human` issue:
+
+```md
+## Background
+
+The Stripe webhook endpoint (tracked in #432) needs a test-mode webhook
+secret in CI so automated tests can verify the signature check.
+
+## Required action
+
+1. Create a test-mode Stripe webhook in the Stripe dashboard.
+2. Store the signing secret in the `STRIPE_WEBHOOK_SECRET` repository
+   secret.
+3. Reply on this issue with the secret name once added.
+
+## Ready signal
+
+Close this issue after confirming the secret is available in CI.
+```
+
+`#432` — autonomous execution issue (Blocked by #431):
+
+```md
+## Background
+
+Parent roadmap: #430
+Blocked by #431
+
+## Proposed change
+
+Add POST /api/webhooks/stripe that validates the Stripe-Signature header
+and dispatches known event types.
+
+## Acceptance criteria
+
+- Handler validates the webhook secret sourced from CI `STRIPE_WEBHOOK_SECRET`.
+- Tests use the Stripe test-mode fixture and pass without manual setup.
+- `pnpm test` and `pnpm run lint` pass in CI.
+```
+
+The autonomous issue is fully verifiable in CI once the credential
+exists. It does not mention a person setting up anything inside its
+acceptance criteria.
+
+### Back-loaded pattern
+
+Use this when post-implementation work is subjective review, publication
+choice, optional polish, or a sign-off that should not block an
+otherwise verifiable core change.
+
+**Good (back-loaded)**: Separate the implementation from the optional
+human-gated step:
+
+Roadmap body excerpt (the `## Tracks` list contains only the ready
+execution issue; the deferred step is a narrative note, not a task-list
+entry):
+
+```md
+## Tracks
+
+- [ ] #441 — add front-loaded/back-loaded draft-pattern examples
+
+## Deferred
+
+The website landing page could be updated to showcase the new examples,
+but that publication decision requires maintainer approval and is not a
+blocker for merging #441. Track in a follow-up if approved.
+```
+
+`#441` — autonomous execution issue:
+
+```md
+## Background
+
+Parent roadmap: #440
+
+The draft-patterns reference file does not yet show front-loaded or
+back-loaded human-dependency isolation patterns.
+
+## Proposed change
+
+Add a "Human-dependency isolation examples" section to
+`skills/issue-authoring/references/draft-patterns.md`.
+
+## Acceptance criteria
+
+- The section includes at least one front-loaded and one back-loaded
+  example using stable bucket names (needs-decision, blocked-by-human,
+  deferred, out-of-scope).
+- Examples warn against hiding credentials or product decisions in a
+  ready issue.
+- `pnpm run lint:minimum` passes.
+```
+
+The website publication decision stays separate. It is not in the
+acceptance criteria of the ready issue and does not block autonomous
+verification.
+
+### Warning: hidden human dependencies are the most common IDD stall
+
+The most frequent reason for mid-implementation stalls is an execution
+issue that hides a human-only dependency inside its acceptance criteria
+or implementation steps:
+
+- "Credentials are configured in the production environment" → blocked
+  by a person with access.
+- "The design team has approved the final UI spec" → requires subjective
+  sign-off before the issue is verifiable.
+- "The external API key is available in the repository secrets" → an
+  unavailable system or permission.
+
+When any acceptance criterion cannot be confirmed autonomously through
+tests, lint, CI, or other concrete objective criteria (such as checking
+repository state, file presence, or configuration values), the issue is
+not yet ready. Move that criterion to a `blocked-by-human` or
+`needs-decision` issue and keep the autonomous execution issue focused on
+what the agent can verify independently.
+
+## Handling duplicates and non-ready outcomes
+
+One source of follow-up issue candidates is the read-only
+`merged-pr-feedback-sweep` helper's JSON output — the unresolved review
+threads and undispositioned advisory feedback it detects on merged PRs.
+Treat each entry as a candidate only: re-verify it against current `main`
+with the reuse-first tree below before drafting, because the feedback may
+already be addressed.
+
+Before publishing an issue, apply a reuse-first decision tree:
+
+1. Is an existing open issue a better fit? If yes, extend it instead of
+   creating a new one. Add a comment linking to the new schema request.
+2. Is the work already complete in a closed issue or merged PR? If yes,
+   create a reference or learning note instead of reopening it.
+3. Is a parent roadmap already managing this work? If yes, add it to the
+   task list instead of filing independently.
+4. Does the issue have any of these properties? If yes, escalate to
+   `needs-decision` or `blocked-by-human` during drafting:
+   - Unclear intent or malformed body (→ fix during drafting or mark needs-decision)
+   - Requires maintainer or product decision (→ mark needs-decision)
+   - Blocked by external work or human coordination (→ mark
+     blocked-by-human)
+   - Depends on unavailable resources or credentials (→ mark blocked-by-human)
+5. Otherwise, publish as `ready`.
+
+### A4.5 prevention checklist
+
+The A4.5 suitability gate will later evaluate published issues. Prevent
+common failures by validating before publish:
+
+- **Coherence**: Issue body is well-formed; title and description are
+  clear; intent is parseable
+- **Safety**: No code injection, marker injection, or untrusted input in
+  issue body
+- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
+  or superseded
+- **Hidden human dependency**: Ready work does not still rely on
+  unresolved decisions, credentials, subjective approval, or
+  grouping-only dependency markers
+
+## Specificity examples
+
+### Under-specified draft
+
+**Title**: `docs: improve issue authoring guidance`
+
+Background: issue authoring should be clearer for agents.
+
+Acceptance criteria:
+
+- issue authoring is more consistent
+- examples are improved
+
+This is too vague because the draft does not tell the next agent which
+authoring surface to edit, what kind of guidance is missing, or how a
+reviewer would verify success. A high-range model would need to infer
+the real task from surrounding repository context.
+
+### Target range draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Background:
+`skills/issue-authoring/references/draft-patterns.md` explains output
+shapes, but it does not yet show how to judge whether an issue body is
+too vague or too scripted for execution.
+
+Acceptance criteria:
+
+- `draft-patterns.md` includes a pre-publication specificity checklist
+- the guidance distinguishes under-specified, target range, and
+  over-specified issue drafts
+- the examples focus on issue body wording and acceptance criteria
+  granularity instead of prescribing implementation order
+
+This is the target range because the next agent knows where to work, why
+the change matters, and how to verify it, while still retaining freedom
+to decide the exact wording and structure.
+
+### Over-specified draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Proposed change:
+
+1. Insert a new `## Specificity target` heading after `## Output chooser`.
+2. Add exactly three bullets named `Under-specified`, `Target range`,
+   and `Over-specified`.
+3. Add a five-item checklist using the exact sentence order shown in the
+   draft.
+4. Copy the same example phrasing across every example block without
+   changing any wording.
+
+This is too detailed for authoring because it turns the issue into an
+implementation script. Reviewers usually need the target outcome and the
+verification shape, not a rigid edit order.
+
+## Publication boundary
+
+If the user asked for drafts only, stop after reporting the issue set,
+assumptions, and non-ready buckets.
+
+If the user explicitly asked to publish issues, create or update them
+and then stop unless they also separately asked to start the IDD
+execution loop.

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -1,0 +1,109 @@
+# Workflow Boundary
+
+This bundle handles pre-approval issue drafting only.
+
+## Handoff sequence
+
+The issue-authoring bundle fits into a three-phase handoff:
+
+### Phase 1: Drafting (this bundle)
+
+- Skill drafts issues in the target repository
+- Issues move through readiness buckets: `deferred` → `ready` or
+  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- User approves the issue set before any publication
+
+### Phase 2: Publishing (user-authorized handoff)
+
+- User explicitly asks for publication
+- Bundled skill resolves the authoring label from
+  `issueAuthoring.authoringLabelName`, defaulting to `status:authoring`
+- If the label does not exist in the target repository, bundled skill
+  creates it with `gh label create` before first use; label creation or
+  application failure blocks publishing
+- For existing issues, bundled skill applies the authoring label before
+  updating issue content
+- For new issues, bundled skill creates the issue with the authoring label
+  when the publication command supports that; otherwise it applies the
+  label immediately after creation
+- If post-create label application fails, bundled skill closes the created
+  issue before stopping; deletion needs admin permission the authoring
+  agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
+  so it is not the default path
+- User verifies the published issues look correct
+- Bundled skill removes the authoring label from all published issues only
+  after the full issue set is published, the user confirms the result, and
+  the user explicitly requests release from the authoring hold for IDD
+  execution
+- If publishing is interrupted before release, the authoring label remains
+  in place as the IDD discover guard signal
+- Published issues remain on hold until user explicitly requests IDD execution
+
+### Phase 3: Execution (separate IDD loop)
+
+- User explicitly asks to start the IDD execution loop
+- Target repository's `.github/instructions/idd-discover.instructions.md`
+  takes over
+- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
+- Suitable issues are claimed, worked, and merged
+
+**Approval boundaries**:
+
+- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
+  issue set
+- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
+  execution
+- **No implicit progression**: Each handoff requires explicit user request.
+  The bundle must not auto-transition to publishing or execution.
+
+## A4.5 Gate Timing
+
+The IDD discover phase evaluates published issues through the A4.5
+pre-claim suitability gate. This gate runs after an issue is published
+but before it is claimed for work.
+
+**Why A4.5 exists**: Issues drafted with incomplete information or from
+assumptions that did not hold when published may fail A4.5 checks
+(incoherent, unsafe, duplicate, etc.). A4.5 catches these before they
+waste agent time during work.
+
+**Prevention during drafting**: This bundle is where coherence, safety,
+and uniqueness should be validated **before** publishing. A4.5 runs
+seven suitability checks; the three that drafting can most directly
+prevent (coherence, safety, uniqueness) correspond to bucket escalation
+triggers during drafting:
+
+- If an issue might be incoherent → escalate to `needs-decision` during
+  drafting
+- If an issue might contain untrusted input → escalate to `blocked-by-human`
+  or fix during drafting
+- If an issue might be a duplicate → run reuse-first checks during
+  drafting before publishing
+
+When these prevent-during-drafting checks are applied correctly, published
+issues will pass A4.5; if they do not, A4.5 will catch them at discover
+time and report the specific failure (unclear, invalid, duplicate).
+
+## Use this bundle to
+
+- prepare IDD-ready orphan issues when the target repository discovers
+  orphans (`issue-scope: roadmap-first`, the default, via the orphan
+  fallback, or `orphan-first`), including any required
+  `orphan-first-policy` approval handoff
+- prepare roadmap packages and child issues when work needs visible
+  sequencing or parallel tracks
+- surface non-ready buckets instead of guessing through blockers
+
+## Do not use this bundle to
+
+- start the Discover -> Claim -> Work loop implicitly
+- treat bundled references as a replacement for repository execution
+  instructions
+- publish issues unless the user explicitly asked for publishing
+
+## Handoff to execution
+
+After the user approves the issue set, wait for a separate request to
+publish the issues or start the IDD execution loop. Only then should
+the workflow hand off to the repository's normal entry file and routed
+`.github/instructions/*.instructions.md` phase files.

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -23,6 +23,10 @@
     "profile": "package-manager"
   },
   "maintainerApprovalActorPolicy": "owners-and-maintainers-only",
+  "issueAuthoring": {
+    "maxClarificationRounds": 3,
+    "authoringLabelName": "status:authoring"
+  },
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "advisoryWait": {

--- a/.github/skills/issue-authoring/SKILL.md
+++ b/.github/skills/issue-authoring/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: issue-authoring
+description: Draft or refine IDD-ready GitHub issues, roadmap issues, and sub-issues before the normal IDD execution loop begins. Use when a request is too large or ambiguous for one reviewable change, when work needs decomposition or dependency encoding, or when the user asks for issue drafting, roadmap planning, or parallelizable task breakdown.
+---
+
+# Issue Authoring
+
+Use this skill to prepare issue-ready work before execution starts.
+Keep the skill concise and treat the repository docs as the canonical
+source for the full contract and schema.
+The canonical source bundle lives in this repository; install copies in
+the agent-specific skill directory your runtime reads.
+
+## Stable Phases
+
+Use two stable phases:
+
+1. **Intake and Clarification** — inspect relevant context, identify
+   ambiguity, run a secondary critique or explicit self-critique, and
+   ask only the questions that block safe issue drafting. Keep
+   clarification bounded; use the repository-local
+   `issueAuthoring.maxClarificationRounds` value when available,
+   otherwise default to 3 rounds. **Under-clarification stop rule**: if,
+   after bounded clarification, you still cannot name the concrete
+   surface to edit or an objective verification for a candidate task,
+   route it to `needs-decision` or ask — do not publish a
+   confidently-vague `ready` issue. Reliability over speed.
+2. **Decompose and Draft** — restate the request in implementation
+   terms, split it into atomic tasks, classify readiness, reuse existing
+   issues when safe, and draft the smallest issue shape that preserves
+   dependencies and reviewability.
+
+Preserve low-readiness work in stable buckets: ready, deferred,
+needs-decision, blocked-by-human, and out-of-scope.
+
+## Workflow
+
+1. Read the bundled contract in
+   [references/contract.md](references/contract.md).
+2. Reuse or extend an existing issue before creating a new one — but
+   never edit the body of an actively-claimed or open-PR issue (its
+   claimed agent will not pick the change up); cover it with a follow-up
+   issue instead. See the contract's claim-state precondition.
+3. Choose the smallest safe output shape:
+   - orphan issue for one ready autonomous task only when the target
+     repository discovers orphans (`issue-scope: roadmap-first`, the
+     default, via the orphan fallback, or `orphan-first`) and any
+     configured `orphan-first-policy` approval step can be completed
+     after drafting
+   - roadmap plus sub-issues for multi-task or multi-session work
+   - stable non-ready buckets for deferred, needs-decision,
+     blocked-by-human, or out-of-scope work
+4. **Prefix-first**: resolve the target repository's marker prefix
+   before emitting any authoring marker — `roadmap-id`, `blocked-by`,
+   `autopilot-suitability`, or `effort`. Use the prefix documented by
+   the target repository's onboarding or IDD docs, and ask the user
+   instead of guessing when the prefix is not discoverable. Never
+   default to this source repository's `idd-skill` prefix in an
+   installed bundle.
+5. Keep dependencies machine-readable and minimal:
+   - roadmap identity via
+     `<!-- <marker-prefix>-roadmap-id: ... -->`
+   - active child issues via roadmap task-list links
+   - issue-to-issue dependencies via `Blocked by #NNN`
+   - sequential roadmap dependencies via
+     `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+     roadmap
+     must close first
+   - keep independent sibling work in roadmap task lists unless a true
+     correctness, availability, or ordering constraint requires a
+     dependency edge
+6. Before publishing a ready orphan, roadmap, or child body, run the
+   `audit-authored-issue` linter against it as the mechanical
+   pre-publish gate — see
+   [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
+   in the bundled contract, including the manual fallback for
+   `instructions-only` installs with no helper runtime. Resolve every
+   reported failure before treating the issue as ready.
+7. When the user explicitly authorizes publication, manage the authoring
+   label for each created or updated issue:
+   - resolve `issueAuthoring.authoringLabelName`, defaulting to
+     `status:authoring`
+   - create the label with `gh label create` before first use when the
+     target repository does not already have it
+   - treat label creation or application failure as a publishing blocker
+   - apply the label before updating an existing issue
+   - create new issues with the label when supported, or apply the label
+     immediately after creation
+   - if post-create label application fails, close the created issue
+     before stopping; deletion needs admin permission the authoring
+     agent typically lacks (and `docs/permissions.md` forbids for normal
+     IDD), so it is not the default path
+   - remove the label from all published issues only after the full set is
+     published, the user confirms the result, and the user explicitly
+     requests release from the authoring hold for IDD execution
+   - leave the label in place if publishing is interrupted before release
+8. Stop at the approval boundary. Drafting issues does not authorize
+   publishing them or starting the IDD execution loop unless the user
+   explicitly asked for that.
+
+## Reference Routing
+
+- For the bundled contract, output schemas, and discoverability guard:
+  read [references/contract.md](references/contract.md).
+- For the bundled boundary between pre-approval drafting and the IDD
+  execution loop: read
+  [references/workflow-boundary.md](references/workflow-boundary.md).
+- For concrete drafting patterns and example prompts: read
+  [references/draft-patterns.md](references/draft-patterns.md).
+- When editing this bundle inside the source repository, keep the
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
+
+## Output Checklist
+
+- Preserve low-readiness work in stable buckets instead of dropping it.
+- Keep acceptance criteria explicitly verifiable.
+- Keep human-dependent setup, review, and approval work isolated from
+  ready execution issues whenever possible.
+- Link every active child issue from its roadmap body.
+- Justify each dependency edge and keep independent sibling work as
+  roadmap task-list entries.
+- Record reuse or extension decisions when the skill does not create a
+  new issue.
+- Avoid widening drafting output beyond the user request without saying
+  so.
+- Run the `audit-authored-issue` linter (or its manual fallback in
+  `instructions-only` installs) against every drafted ready body and
+  resolve every reported failure before publishing.
+- Name a concrete surface to edit and an objective verification for
+  every `ready` candidate; route anything else to `needs-decision` or
+  ask instead of guessing (the under-clarification stop rule).
+- Resolve the target repository's marker prefix before emitting any
+  authoring marker; never assume this source repository's `idd-skill`
+  prefix in an installed bundle (the prefix-first rule).

--- a/.github/skills/issue-authoring/agents/openai.yaml
+++ b/.github/skills/issue-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Authoring"
+  short_description: "Draft IDD-ready issues and roadmaps"
+  default_prompt: "Use $issue-authoring to draft an IDD-ready issue set for this request."

--- a/.github/skills/issue-authoring/references/contract.md
+++ b/.github/skills/issue-authoring/references/contract.md
@@ -1,0 +1,847 @@
+# Bundled Issue Authoring Contract
+
+This file keeps the `issue-authoring` bundle usable when it is installed
+or copied outside this repository root. It mirrors the canonical
+contract in `docs/issue-authoring-skill.md`.
+
+## Target marker prefix
+
+**Prefix-first**: resolve the target repository's hidden marker prefix
+before emitting _any_ authoring marker — `roadmap-id`, `blocked-by`,
+`autopilot-suitability`, or `effort`. Resolve it once, up front, not as
+an afterthought once a marker is already half-drafted.
+
+- Use the prefix documented by the target repository's onboarding or
+  IDD instructions.
+- In this source repository the prefix is `idd-skill`, but installed
+  bundles must not assume that value elsewhere. Never default to
+  `idd-skill` in an installed bundle; use it only when the target
+  repository actually configured that value.
+- If the prefix is not discoverable from the repository docs or user
+  context, stop and ask instead of emitting a guessed marker.
+
+## Trigger policy
+
+Use this bundle when direct implementation would skip the issue hygiene
+that the IDD execution loop depends on.
+
+Invoke it when one or more of the following are true:
+
+- the request is too large or ambiguous for one reviewable change
+- the likely solution needs decomposition into multiple atomic tasks
+- dependencies or execution order must be made explicit before work can
+  start safely
+- the user wants a roadmap, issue breakdown, or parallelizable work
+  plan
+
+Skip it when all of the following are true:
+
+- the task fits one reviewable change
+- verification is already clear
+- no roadmap, dependency marker, or issue split is needed
+- the user did not ask for issue drafting first
+
+## Stable phases
+
+The bundle uses two stable phases. These names mirror the canonical
+contract and should stay stable for copied bundles.
+
+### 1. Intake and Clarification
+
+In this phase, the agent:
+
+- inspects the relevant code, docs, and existing issues
+- identifies assumptions and ambiguity that affect issue quality
+- runs a secondary critique pass before drafting
+- asks the user only the questions that block safe issue drafting
+
+The critique pass is agent-neutral: use a subagent or rubber-duck
+reviewer when available, otherwise run an explicit self-critique
+locally. Clarification must be bounded; use the repository-local
+`issueAuthoring.maxClarificationRounds` value when available,
+otherwise default to 3 rounds. If safe drafting is still impossible
+after that, stop and report the remaining blockers instead of looping
+indefinitely.
+
+**Under-clarification stop rule.** If, after bounded clarification, you
+still cannot name the concrete surface to edit or an objective
+verification for a candidate task, route it to `needs-decision` or ask
+— do not publish a confidently-vague `ready` issue. Reliability over
+speed. This is distinct from the "Under-specified" specificity band
+below: that band judges an already-drafted body's wording, while this
+rule stops publication earlier, during Intake, before a body is even
+drafted.
+
+### 2. Decompose and Draft
+
+In this phase, the agent:
+
+- restates the clarified request in implementation-facing terms
+- splits work into atomic tasks
+- checks whether each task is suitable for autonomous execution
+- reuses or extends existing issues before creating new ones
+- drafts orphan issues, roadmap packages, sub-issues, or non-ready
+  buckets as appropriate
+
+## Readiness buckets
+
+Do not silently drop low-confidence or low-readiness work. Route each
+candidate task into one stable bucket:
+
+- **ready**: passes limited scope, clear verification, and autonomous
+  completion
+- **deferred**: plausible, but priority, timing, or decomposition is not
+  strong enough for execution
+- **needs-decision**: depends on a product, policy, or design choice
+- **blocked-by-human**: waits on a person, credential, asset, or outside
+  system
+- **out-of-scope**: does not belong in the repository or skill scope
+
+## Specificity target
+
+Issue drafting should aim for a level of specificity where a
+middle-tier cloud model can implement the task without drifting. This
+is a practical drafting heuristic, not a hard model requirement. The
+goal is to avoid both hidden assumptions that only a top-tier model can
+infer and step-by-step runbooks that cost too much to author.
+
+### Three specificity bands
+
+| Band                | Practical signal                                                                                                          | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class                                                           | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class can implement the issue without drifting                                                  | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+
+The capability tiers above are practical heuristics, not a fixed
+compatibility matrix or runtime requirement.
+
+### How the specificity target interacts with readiness
+
+This heuristic does not replace the IDD execution axes:
+
+- **Limited scope** still decides whether the work fits one issue or
+  needs a roadmap.
+- **Clear verification** still decides whether success is objectively
+  checkable.
+- **Autonomous completion** still decides whether the task can finish
+  without outside coordination.
+
+An issue can be specific yet still fail A4 or A4.5 because it is too
+broad, not verifiable, or blocked on a human decision. Conversely, an
+issue that passes those gates can still be under-specified if it leaves
+too much implementation shape implicit. The drafting target is therefore
+"ready and stable for a middle-tier model," not "maximally detailed."
+
+## Executability gate for code spec-units
+
+For a **code spec-unit** — a drafted unit whose acceptance criteria are
+objectively executable (a script, function, or test the drafted issue
+itself specifies) — an authoring session can validate the draft before
+publishing by building a throwaway reference implementation against its
+own stated acceptance check and accepting the draft only if that
+reference implementation passes. This reuses the downstream execution
+loop as an upstream ground-truth gate: it catches drafts whose
+acceptance criteria are internally inconsistent, non-trivially
+unsatisfiable, or otherwise not actually implementable, before a
+downstream executor ever claims the issue. The reference implementation
+is a discarded validation probe, never published — it does not cross the
+Publication boundary below; only the drafted issue itself is published,
+and building the probe does not start the IDD execution loop.
+
+This is a **recommended practice for repositories or domains where a
+drafted code spec-unit has an objectively executable acceptance
+check**, not a change to this repository's own mechanical
+`bin/idd-audit-authored-issue.mjs` checks or a new requirement on this
+repository's own issue-authoring practice — most of this repository's
+issues are multi-file engineering changes without a single executable
+acceptance check to validate against.
+
+- **Weak-model semantic self-review stays advisory.** When a weak
+  authoring model reviews its own draft for semantic quality, treat the
+  verdict as advisory only, never a hard veto on publishing — mirroring
+  the narrow-question guidance for weak-model judgment calls in
+  `docs/idd-workflow.md`'s Weak-model guardrails section.
+- **Decompose and draft want different model traits.** Decomposition
+  (judgment about scope and structure) tolerates a verbose reasoning
+  model; the structured draft step (emitting the exact spec/acceptance-
+  criteria block) is more reliable on a leaner, more literal model,
+  whose chain-of-thought does not compete with the drafted block for
+  token budget. Pick the model per sub-task, not per pipeline, when both
+  are available.
+- **Redraft and re-decomposition are limited rescue mechanisms, not
+  reliable fixes.** A bounded redraft loop tends to re-roll rather than
+  converge, because a weak author regenerates rather than incrementally
+  fixes. Re-decomposing a repeatedly-failing unit is usually low-value
+  too: most authoring failures are hard-but-atomic rather than
+  over-broad, and splitting a hard-but-atomic unit tends to produce
+  incoherent sub-units that do not recompose. Treat a code spec-unit
+  that repeatedly fails this gate as a candidate for `needs-decision` or
+  human/stronger-model authoring instead of looping indefinitely.
+
+## Reuse-first issue policy
+
+Before creating any new issue, check whether the work already has a
+suitable home.
+
+**Claim-state precondition (check this first).** Before reusing or
+extending _any_ existing issue, determine whether it has an **active
+claim** (its latest valid `claimed-by` comment is newer than the
+configured `claim-stale-age`; distributed default 24 h) or an **open
+PR**, or is otherwise actively executing. If so, you **MUST NOT edit its
+body**: the working agent snapshots the issue body into its B2 plan and
+treats that plan as authoritative — it never re-reads the body, so a
+post-claim body edit is silently lost and becomes an implementation gap.
+You **may** add a separate **comment** (never an edit or append to the
+body), but **must not** rely on the claimed agent acting on it. Cover
+the intended change with a **follow-up issue** (or a roadmap track around
+it), and you **SHOULD** post a cross-reference comment on the claimed
+issue linking the follow-up. Stale or reclaimable claims (latest
+`claimed-by` older than `claim-stale-age`) are exempt — the next claimer
+re-reads the latest body, so editing them is safe.
+
+Then apply these checks in order:
+
+1. If an existing open issue already matches the task and only lacks the
+   new schema details, extend that issue instead of cloning it.
+2. If an existing open roadmap already owns the initiative, add or
+   refine task-list entries there instead of creating a competing
+   umbrella.
+3. If an existing issue is close but too broad, split follow-up work
+   out of it rather than widening the original issue further. When the
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
+4. If an existing issue has an **active claim**, an open PR, or is
+   otherwise being actively executed, do **not** edit its body or
+   repurpose it (see the claim-state precondition, which exempts
+   stale/reclaimable claims); create a follow-up issue or extend the
+   roadmap around it instead.
+5. Create a brand-new issue only when no existing issue can absorb the
+   work without harming ownership, clarity, or reviewability.
+
+Report when the bundle reuses, extends, or declines to reuse an issue
+so a later session can follow the reasoning.
+
+**Recent-window scan for just-discovered problems.** The checks above
+assume the work already has a candidate home to reuse or extend. When
+instead authoring an ad hoc issue for a problem **just discovered**
+during the current session — a build-breaking regression noticed
+mid-session, for example, rather than a task drafted from an existing
+backlog — run a recent-window duplicate scan immediately before
+publishing: list the newest issues regardless of state and check
+whether a concurrent session already authored the same problem.
+
+```sh
+gh issue list --repo <owner>/<repo> --state all --limit 20
+# or, scoped to a recency window:
+gh issue list --repo <owner>/<repo> --state all --search "created:>=<YYYY-MM-DD>"
+```
+
+A hit routes back into the checks above: extend the discovered issue
+instead of publishing a duplicate. When the race slips past this scan
+anyway (near-simultaneous discovery), the outcome is **anticipated and
+self-resolving, not a coordination failure**: both sessions proceed
+independently through their own claim and implementation cycle;
+whichever PR merges first wins; the other session manually verifies
+the fix already landed on the default branch, then closes its own
+issue and (unmerged) PR as superseded, citing the verifying evidence.
+This is the same manual verify-then-close judgment call the execution
+loop's B2.0 supersession re-check (`idd-work.instructions.md`) applies
+after claim — this scan only adds an earlier, pre-publish checkpoint.
+A fast enough race can still surface even after B2.0; when it does, it
+resolves the same way.
+
+## Output chooser
+
+Choose the smallest safe output shape:
+
+- **Orphan issue**: one autonomous task can finish the work, no
+  roadmap-level coordination is needed, and the target repository
+  discovers orphans — i.e. `issue-scope` is `roadmap-first` (the
+  default; orphans are picked up as the fallback when no roadmap work is
+  startable) or `orphan-first` (orphans first). If the repository uses
+  `orphan-first-policy: maintainer-approved`, surface the required
+  post-publication maintainer approval step. If the repository sets
+  `issue-scope: roadmap` (roadmap-only) or disables public orphan-first
+  discovery with `orphan-first-policy: public-disabled`, surface that
+  constraint and prefer a roadmap package instead.
+- **Roadmap plus sub-issues**: the request needs visible sequencing,
+  parallel tracks, multiple ready issues, or multi-session handoff.
+- **Stable non-ready buckets**: some work is deferred, blocked by a
+  human, waiting on a decision, or outside the repository scope.
+
+When the repository keeps the broader issue-author approval gate,
+surface the same post-publication approval step for orphan issues,
+roadmaps, and sub-issues whenever the issue author is not
+self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is satisfied,
+route the draft to the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+## Human-dependency isolation
+
+Treat unresolved human dependency as a side effect that should be
+isolated away from ready execution issues whenever possible.
+
+- **Front-load** human-dependent work when coding cannot start safely
+  until a person provides a decision, credential, permission,
+  maintainer-only action, external setup, or policy choice, or until an
+  unavailable system becomes usable again.
+- **Back-load** human-dependent work when the remaining dependency is
+  subjective review, publication choice, optional polish, or another
+  post-implementation judgment that should not block an otherwise
+  autonomous core change.
+- Keep the central execution issue as close as possible to a pure
+  autonomous unit: clear repository-local scope, no hidden human handoff
+  in the implementation steps or acceptance criteria, and objective
+  verification.
+- Preserve unavoidable human-dependent work in an explicit stable
+  bucket, dependency edge, or approval-needed hold rather than mixing it
+  into a ready issue.
+- Route unresolved choices to `needs-decision`, route waiting on people,
+  credentials, maintainer-only actions, or unavailable systems to
+  `blocked-by-human`, use `deferred` when timing or decomposition is not
+  strong enough yet, and keep approval-gated ready work in the
+  approval-needed hold instead of the normal ready-to-start set.
+- If a task cannot be expressed without unresolved human coordination in
+  the middle of implementation, it is not yet `ready`.
+
+This principle complements the execution axes rather than replacing
+them: it is a practical way to protect autonomous completion and clear
+verification during issue drafting.
+
+## Hidden human-dependency validation
+
+Before publishing a `ready` issue, run a short pre-publication check for
+hidden human dependency. Treat this as a routing aid, not a rigid
+wording linter: the question is whether the work still depends on
+unresolved human action, not whether the draft used one forbidden
+phrase.
+
+Ask these checks:
+
+1. Does implementation require credentials, external access, hardware,
+   or infrastructure that the executing agent cannot already reach? If
+   yes, route the work to `blocked-by-human` unless that dependency can
+   be front-loaded into a separate prerequisite issue.
+2. Does any implementation step or acceptance criterion depend on a
+   product, policy, or design decision that has not been made? If yes,
+   route the work to `needs-decision`.
+3. Do the acceptance criteria require subjective human approval instead
+   of objective verification? If yes, rewrite the ready issue around
+   measurable checks and back-load the optional review or publication
+   judgment.
+4. Does a roadmap narrative hide human-dependent work inside prose while
+   the visible task list presents the item as execution-ready? If yes,
+   preserve that work in an explicit stable bucket, approval-needed
+   hold, or blocking issue instead of burying it in the narrative.
+5. Is any dependency marker being used only to group related work or
+   express preference order? If yes, remove the fake blocker and use
+   task-list structure or sequencing notes instead. Keep dependency
+   edges only for true start blockers.
+
+Normal post-implementation code review, merge approval, or publication
+choice does not by itself make an otherwise autonomous issue non-ready.
+The ready issue should still carry its own objective verification even
+when a human will look at the result afterward.
+
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
+
+## Dependency minimization
+
+Encode a dependency edge only when it reflects a true correctness,
+availability, or ordering constraint.
+
+- keep independent sibling tasks as roadmap task-list entries, with
+  short sequencing or parallelization notes when that helps reviewers or
+  later agents
+- use visible or sequential dependency markers only when the issue
+  cannot start safely until the dependency resolves
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
+
+When an issue keeps a dependency edge, justify each dependency edge in
+the surrounding issue body and confirm that the split still preserves
+natural cohesion.
+
+## Nested roadmap nodes
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. A nested roadmap
+is still a roadmap node, not a normal execution candidate.
+
+Authoring rules:
+
+- reference the nested roadmap from the parent roadmap task list instead
+  of hiding it in prose
+- give the nested roadmap its own roadmap marker and `## Tracks` section
+  that links the active child work it coordinates
+- treat the nested roadmap as a coordination/audit node for discovery
+  and roadmap audit; do not draft it as normal A3/A4/A5 execution work
+- use two-level or three-level nesting only when the intermediate
+  roadmap has its own active child work or handoff boundary
+- do not use `Blocked by #NNN` or
+  `<!-- <marker-prefix>-blocked-by: ... -->` only to group leaf issues
+  under an active nested roadmap; reserve those encodings for true
+  execution dependencies or sequential roadmap dependencies between
+  separate roadmaps
+
+Validation expectations:
+
+- each nested roadmap node is linked from its parent roadmap task list
+- each nested roadmap node links its own active child work from its body
+- cycles, duplicate references, and closed intermediate roadmaps with
+  hidden open descendants must be surfaced as validation failures or
+  explicit follow-up notes, not silently normalized away
+
+## Required dependency encoding
+
+- Roadmap identity via `<!-- <marker-prefix>-roadmap-id: ... -->`
+- Active child issues via roadmap task-list links
+- Issue-to-issue dependencies via `Blocked by #NNN`
+- Sequential roadmap dependencies via
+  `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+  roadmap
+  must close first
+
+## Required draft content
+
+### Orphan issue
+
+- title with a concise user-facing summary
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
+  see [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- no `<marker-prefix>-roadmap-id` marker
+- no `<marker-prefix>-blocked-by` marker
+- acceptance criteria are explicitly verifiable
+- the issue stays discoverable under the target repository's
+  `issue-scope` setting
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+### Roadmap issue
+
+- title that describes the umbrella initiative
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- every active child issue or nested roadmap node is referenced from the
+  roadmap body
+- the roadmap explains why multiple issues exist
+- sequencing and blocking are explicit
+- each dependency edge is justified and preserves natural cohesion
+- nested roadmap entries stay identifiable as coordination/audit nodes
+  instead of normal execution leaves
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+### Child issue under a roadmap
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
+
+Validation expectations:
+
+- the issue is referenced from its parent roadmap task list
+- acceptance criteria are locally verifiable
+- any dependency marker is resolvable, intentionally chosen, and
+  justified
+- the issue can be claimed independently without absorbing sibling work
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+## A4.5 Suitability Gate Alignment
+
+When an issue is published and reaches the IDD discover phase, the A4.5
+pre-claim gate will evaluate it against seven suitability checks. The
+authoring skill should catch these issues before publishing:
+
+| Check                    | Authoring Bucket     | How to Prevent                                                                  |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------- |
+| Repository Fit (Check 1) | `out-of-scope`       | Ensure issue is scoped to this repository; escalate if it crosses boundaries    |
+| Coherence (Check 2)      | `ready` or escalated | Validate issue body against schema before publish                               |
+| Safety/trust (Check 3)   | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
+| Duplicates (Check 4)     | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
+| Actionability (Check 5)  | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
+| Autonomy (Check 6)       | `ready` or escalated | Ensure agent can complete without external coordination                         |
+| Verifiability (Check 7)  | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
+
+Pre-publish validation checklist:
+
+1. **Coherence**: Issue body is well-formed, title+description are
+   clear, intent is parseable
+2. **Safety**: No code injection, marker injection, or untrusted input
+   in issue body
+3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded
+   work
+4. **Human dependency isolation**: Ready issues do not hide unresolved
+   decisions, credentials, subjective approvals, or mid-implementation
+   human handoffs
+5. **Mechanical audit**: the drafted body passes the
+   `audit-authored-issue` linter for its declared shape (see
+   [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+If any check is uncertain, route the issue to `needs-decision` or
+`blocked-by-human` during drafting instead of publishing a
+marginally-ready issue.
+
+## Mechanical pre-publish gate
+
+Before publishing a drafted `ready` **orphan, roadmap, or child** body
+(the shapes the linter supports — not the non-ready buckets below,
+which are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime is
+available. It mechanically re-checks a subset of the structural rules
+this contract states in prose — the autopilot-suitability marker's
+exactly-one/coherent-value rule, the one-directional check that a
+suitability score of `1` carries the configured `blocked-by-human`
+label (it does not check the reverse: a non-`1` score paired with the
+label still passes), markerPrefix consistency across every authoring
+marker, the declared shape's required section headings, the
+roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
+agreement for the suitability and effort footers — so a weak model does
+not have to hold every rule in its head at once while drafting.
+
+The linter also emits one **advisory, warning-severity-only** finding
+(`prose-dependency`): it flags an issue/PR reference (`#<digits>` or a
+full GitHub issue/PR URL) that appears near coordination language (for
+example "before", "after", "once", "until", "predates", "gate"/"gated",
+"requires", "lands first") with no corresponding encoding for that
+reference as one of the three recognized forms: a `Blocked by #NNN`
+line, a `Depends on #NNN` line, or a task-list checkbox item
+(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
+`extractDependencyIssueNumbers` already recognize elsewhere in this
+contract. A task-list checkbox counts regardless of which heading it
+sits under, so a roadmap's own `## Tracks` membership list already
+satisfies this — it is not a separate "dependency-only" list. This
+catches the pattern this contract's own
+[Hidden human-dependency validation](#hidden-human-dependency-validation)
+check 4 warns about in prose — a hard precondition stated only in
+narrative text, not encoded as a real dependency marker. A full-URL
+reference is inherently local only when it actually names the current
+repository, since a cross-repo dependency cannot be encoded with these
+repository-local markers at all — flagging it would recommend an
+impossible fix. When the caller supplies the current `owner/repo`
+(`--current-repo`, defaulting to `$GITHUB_REPOSITORY` in CI), a
+full-URL reference naming a different repository is never flagged;
+without that context, a full-URL reference is still flagged by
+default (unchanged behavior) — unless its issue/PR number happens to
+already appear as a local `Blocked by` / `Depends on` / task-list
+marker elsewhere in the body, in which case it is treated as already
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for every nested child under a given parent, at any depth — not
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
+`prose-dependency` warning never flips `passed` to `false` and never
+changes the linter's exit code: it prompts the author to either
+convert the prose into a proper dependency marker or consciously
+confirm the reference is a mere breadcrumb.
+
+```sh
+node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
+  --marker-prefix <resolved-target-prefix> \
+  --body-file <path-to-drafted-body> [--label <label>]...
+```
+
+Or, for npx/package-manager profiles, the equivalent
+`idd-audit-authored-issue` command. Pass `--stdin` instead of
+`--body-file` when the drafted body is not yet written to disk.
+**Always pass `--marker-prefix`** with the prefix resolved under
+[Target marker prefix](#target-marker-prefix): without it, the linter
+falls back to reading `.github/idd/config.json` from the current
+working directory, and if that file is missing or unreadable — for
+example when running from an installed bundle without a local
+checkout of the target repository's config — it silently defaults to
+this source repository's own `idd-skill` prefix, which produces a
+false pass or fail against the wrong prefix instead of an error.
+
+**No helper runtime available (`instructions-only` profile).** The
+linter cannot run without Node.js and the vendored `scripts/`
+directory, and an `instructions-only` install is a first-class
+supported fallback, not a degraded one. Unavailability is never a
+waiver: manually re-verify the same checks listed above against this
+contract's prose and the [Draft schemas](#required-draft-content)
+before publishing.
+
+A `passed: false` report (or non-zero exit, or a failed manual
+re-verification) means the draft is not ready to publish yet,
+regardless of how complete the narrative reads — fix every reported
+finding and re-run before treating the issue as `ready`. The linter (or
+its manual equivalent) is a mechanical structural check, not a
+substitute for the judgment-based checks above (human-dependency
+isolation, codebase fidelity, reuse-first) — passing it is necessary,
+not sufficient, for `ready`.
+
+## Autopilot-suitability score
+
+> **Status.** Active contract. Authoring **emits** the score footer
+> and Discover **ranks and routes** candidates by it (roadmap #759,
+> fully merged). The score stays advisory: it never bypasses the
+> A4.5/A5 gates and is fail-safe on absence.
+
+Authored issues carry a persisted **autopilot-suitability score**
+from 1 to 5 (higher = more autopilot-suitable). It is the durable,
+graded form of the **Autonomous completion** execution axis: the
+author makes the judgment once, while context is fresh, so the
+Discover phase can rank and route candidates by a cheap read
+instead of re-deriving autonomy per candidate.
+
+| Score | Meaning                     | Typical signals                                                                                                          |
+| ----- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 5     | Autopilot-ideal             | Fully specified; deterministic verification (tests/lint/CI/mechanical); no external systems; no human judgment; isolated |
+| 4     | Strongly autopilot-suitable | Well-specified and verifiable; minor ambiguity resolvable from repo context; no external/human dependency                |
+| 3     | Borderline / mixed          | Autopilot can likely finish but with notable judgment, weaker verification, or review-attention risk                     |
+| 2     | Mostly human                | Agent may draft a partial result; completion needs human judgment, an asset, or review the agent cannot supply           |
+| 1     | Human-only                  | Interactive credentials, real deployment, subjective/design/product judgment, or external coordination                   |
+
+Scores below the configured discovery floor
+(`autopilotSuitability.floor`, default `3`) designate
+**human-oriented issues**: in autopilot runs Discover routes them
+to humans rather than autopilot.
+
+The score is recorded as a **footer at the end of the issue
+body** — a visible line paired with a hidden, prefix-aware
+machine marker, mirroring the `claimed-by` convention (visible
+note + HTML marker):
+
+```text
+---
+
+_Autopilot suitability: N / 5 -- higher is more autopilot-suitable;
+below the configured floor is human-oriented._
+
+<!-- {marker-prefix}-autopilot-suitability: N -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware via
+  `createMarkerRegex(markerPrefix, "autopilot-suitability")` exactly
+  as `roadmap-id` / `blocked-by` are. `N` is an integer 1-5. The
+  visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** This is body
+  content like `roadmap-id`; it must never be added to
+  `OPERATIONAL_MARKERS` in `scripts/protocol-helpers.mjs` or
+  subjected to F4 minimization.
+- **One source of truth.** A score of `1` must agree with
+  `status:blocked-by-human`; never publish a contradiction.
+- **Advisory, never a gate.** The score only ranks/routes
+  candidates. The A4.5 suitability gate and A5 claim safety checks
+  still run unchanged on whatever issue is selected; a high score
+  never bypasses a gate.
+- **Fail-safe on absence.** A missing, non-integer, or
+  out-of-range marker means "no score": Discover evaluates the
+  issue the normal way and never skips it. Pre-existing issues
+  with no score keep flowing.
+
+Backfill is opportunistic: when an existing open issue without a
+score footer is next edited by the authoring flow, add one. No
+bulk backfill of the existing backlog is required. The claim-state
+precondition still applies — never add the footer to the body of an
+actively-claimed or open-PR issue; defer it to a follow-up instead.
+
+## Effort hint
+
+Authored issues may also carry an **effort hint** — an author-time
+`S | M | L` size estimate, recorded once while context is fresh, that
+Discover consumes as a **soft selection tie-breaker** so autopilot tends
+to clear small issues first and leave large ones for a fresh session.
+Effort is distinct from the autopilot-suitability score: suitability
+captures _autonomy_ (can an agent finish unattended), while effort
+captures _size_ (a fully-autonomous issue can still be large).
+
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
+
+The hint is recorded as a **footer at the end of the issue body** — a
+visible line paired with a hidden, prefix-aware machine marker, beside
+the autopilot-suitability footer:
+
+```text
+---
+
+_Effort: S | M | L -- author-estimated size; a soft autopilot
+selection tie-breaker only._
+
+<!-- {marker-prefix}-effort: S|M|L -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware exactly
+  as `autopilot-suitability` is. `S | M | L` is upper-cased on parse.
+  The visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Soft tie-breaker, never a gate.** Effort only reorders candidates
+  **within** a single suitability-score band, after the score and
+  optional desync rules and **before** the lowest-issue-number tie-break.
+  It never skips, gates, crosses a score band, or bypasses the A4.5/A5
+  gates, and a large (`L`) issue stays fully claimable when it is the only
+  ready work.
+- **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
+  marker means "no effort hint": selection behaves exactly as it does
+  today (a missing hint sorts as the neutral middle, as-if `M`).
+  Pre-existing issues with no effort footer keep flowing.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
+
+## Publication boundary
+
+Drafting issues does not authorize publishing them or starting the IDD
+execution loop unless the user explicitly asked for that next step.

--- a/.github/skills/issue-authoring/references/draft-patterns.md
+++ b/.github/skills/issue-authoring/references/draft-patterns.md
@@ -1,0 +1,598 @@
+# Draft Patterns
+
+Load this file after reading
+[`contract.md`](contract.md) when you need concrete examples or a quick
+chooser for output shapes.
+
+## Example triggers
+
+- "Break this request into IDD-ready issues before we implement
+  anything."
+- "Draft a roadmap for this feature and split the ready work."
+- "Turn this broad request into reviewable orphan issues."
+- "Check whether an existing issue should be extended instead of opening
+  a new one."
+
+## Output chooser
+
+Draft an orphan issue only when one autonomous task can finish the work
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
+maintainer-approved`, include a post-publication approval step after the
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
+`orphan-first-policy: public-disabled`, draft a roadmap package instead.
+
+If the repository keeps the broader secure-by-default issue-author
+approval gate, use the same post-publication approval note whenever the
+issue author will not be self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is
+satisfied, later discovery should treat the issue as part of the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+Draft a roadmap plus sub-issues when the request needs visible
+sequencing, parallel tracks, or multi-session handoff.
+
+Draft only stable non-ready buckets when the work still depends on a
+human decision, missing asset, or unclear verification.
+
+## Under-clarification stop rule
+
+Before drafting a `ready` issue, confirm you can name a concrete surface
+to edit and an objective verification for it. If, after bounded
+clarification, you still cannot, route the candidate to `needs-decision`
+or ask — do not publish a confidently-vague `ready` issue. Reliability
+over speed.
+
+This is an Intake-phase gate on your own confidence, not a wording
+judgment on an already-written draft — it is distinct from the
+"Under-specified" band in the next section, which assesses a body that
+has already been drafted.
+
+**Example**: "Improve the error handling in the API layer" fails this
+check — no concrete surface, no objective verification — even before
+you consider how detailed to write the body. Ask which endpoint or
+module, and what the observable failure mode is, or route the request
+to `needs-decision` instead of guessing at a plausible-sounding scope.
+
+## Specificity target
+
+Execution-ready issue drafts should land in a middle band:
+
+- **Under-specified**: a high-range model still has to infer the real
+  implementation shape because the issue names only a vague goal,
+  omits the likely surface to edit, or leaves verification too loose.
+- **Target range**: a solid mid-tier cloud model can hold a stable plan
+  without extra clarification. The issue points at the relevant
+  document, schema, or code surface, explains the constraint, and keeps
+  acceptance criteria verifiable without dictating every edit.
+- **Over-specified**: even a lightweight model could follow the issue as
+  a script because the body prescribes exact edit order, wording, or
+  implementation steps that reviewers do not need.
+
+If a draft feels like it needs a high-range model just to guess the intended
+change, it is still too vague. If it reads like line-by-line assembly
+instructions, it is too detailed.
+
+## Specificity checklist before publishing
+
+Before you publish a ready issue, confirm:
+
+- the title and background name the concrete artifact or surface that
+  should change
+- a mid-tier cloud model could choose a stable implementation direction
+  without hidden repository archaeology or a follow-up clarification loop
+- the acceptance criteria verify the outcome, not a step-by-step
+  implementation recipe
+- candidate files, examples, and notes act as cues rather than an
+  exhaustive script
+- removing one concrete detail would make the issue feel high-range-only,
+  while adding more detail would start turning it into a lightweight
+  model script
+
+## Mechanical pre-publish gate
+
+Before you publish a drafted **ready orphan, roadmap, or child** body
+(scoped to those ready shapes — non-ready buckets like
+`blocked-by-human` are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime
+is available. It mechanically catches shape and marker mistakes — a
+missing or duplicated autopilot-suitability footer, a wrong
+markerPrefix, a missing required heading for the declared shape, a
+malformed dependency marker — that a confident narrative can otherwise
+mask:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+**Always pass `--marker-prefix`** with the prefix resolved under
+[contract.md's Target marker prefix](contract.md#target-marker-prefix):
+without it, the linter falls back to reading
+`.github/idd/config.json` from the current working directory, and
+silently defaults to this source repository's own `idd-skill` prefix
+when that file is missing or unreadable — producing a false pass or
+fail against the wrong prefix instead of an error.
+
+Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
+instead of `--body-file` when the draft is not yet on disk, and
+`--label <name>` (repeatable) to pass proposed labels for the check
+that a suitability score of `1` carries the configured
+`blocked-by-human` label (default `status:blocked-by-human`; use
+`--config <path>` to point at a policy that overrides the label name —
+this check is also one-directional, it does not flag the reverse, a
+non-`1` score paired with the label). Fix every reported finding and
+re-run before publishing; a `passed: false` report means the draft is
+not ready yet, regardless of how complete the narrative reads.
+
+**No helper runtime available (`instructions-only` profile):** the
+linter cannot run. `instructions-only` is a first-class supported
+fallback, not a waiver — manually re-verify the same checks against
+[contract.md's Mechanical pre-publish gate](contract.md#mechanical-pre-publish-gate)
+before publishing instead.
+
+## Hidden human-dependency quick check
+
+Before you publish a `ready` issue, confirm:
+
+- the implementation does not still depend on unresolved credentials,
+  access, or unavailable infrastructure
+- unresolved product, policy, or design choices have been routed to
+  `needs-decision` instead of being buried in implementation steps
+- acceptance criteria use objective verification, while optional
+  post-implementation review stays optional
+- roadmap narrative does not hide human-dependent work that belongs in a
+  stable bucket or approval-needed hold
+- dependency markers represent true start blockers rather than grouping
+  related work
+
+## Codebase-fidelity quick check
+
+Before you publish a `ready` issue, confirm:
+
+- when the issue reuses an existing identifier or field name, the
+  specified value matches that name's established semantics in the
+  codebase — it does not overload a name with a new shape or source
+- values that are mutable at runtime are flagged to specify a live read
+  at the point of use rather than a one-time capture at construction
+
+## Example orphan issue
+
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional `## Candidate files`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+
+Use this shape when the work is narrow enough to pass the IDD viability
+gate on its own and the target repository can actually discover orphan
+issues (`issue-scope: roadmap-first`, the default, via the orphan
+fallback, or `orphan-first`). If the repository sets
+`issue-scope: roadmap` (roadmap-only), prefer a one-item roadmap package
+instead of publishing a standalone orphan issue.
+
+## Example roadmap package
+
+Roadmap issue:
+
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: ... -->` marker
+- an autopilot-suitability footer at the end of the body
+
+Child issue:
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body
+
+Keep ready child issues in the roadmap task list rather than grouping
+them with hidden dependency markers.
+
+## Nested roadmap chooser note
+
+Use a nested roadmap when one roadmap track needs its own coordination
+boundary, active child list, or multi-session handoff. Keep the parent
+roadmap pointing to the nested roadmap, and keep the nested roadmap
+pointing to the leaf execution issues it coordinates.
+
+Parent roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #510 — backend track roadmap
+```
+
+Nested roadmap `#510` `## Tracks` excerpt:
+
+```md
+- [ ] #511 — define the backend contract
+- [ ] #512 — wire the contract into Discover
+```
+
+Treat `#510` as a coordination/audit node, not as a normal execution
+issue. Do not replace that relationship with `Blocked by #NNN` or
+`<!-- <marker-prefix>-blocked-by: ... -->` only to group the leaf
+issues under the parent roadmap.
+
+## Dependency minimization examples
+
+### Natural parallel decomposition
+
+Roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #401 — update the issue-authoring contract
+- [ ] #402 — add draft-pattern examples
+
+_Parallel note: #401 and #402 can proceed independently once the roadmap
+exists because neither task depends on the other's output._
+```
+
+This is the preferred shape for sibling tasks that can be reviewed and
+verified independently. The roadmap keeps both tasks visible in its task
+list, and the short note explains the safe parallelism without adding a
+fake `Blocked by` edge.
+
+### Artificial decomposition
+
+Bad serial chain:
+
+```md
+#401 — update the issue-authoring contract
+#402 — add draft-pattern examples
+
+Blocked by #401
+```
+
+This is over-serialized when `#402` can be reviewed and verified without
+waiting for `#401`. Do not create a serial chain just to make the order
+feel tidy.
+
+Bad split for parallelism:
+
+```md
+#410 — add one checklist bullet
+#411 — add one example paragraph
+#412 — add one anti-pattern sentence
+```
+
+This is an artificial split when the three edits form one natural,
+cohesive authoring change. Do not break a single reviewable task into
+multiple sibling issues only to widen parallel execution.
+
+### Finalize or verify track that asserts sibling-produced state
+
+Anti-pattern — prose sequencing only:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+
+_Runs after the wiring tracks #441-#445._
+```
+
+The hard `Blocked by #440` names only the build foundation, and the
+after-the-siblings ordering lives in prose. Once `#440` closes, Discover
+reports `#450` startable and A4.5 passes it (Actionability inspects the body,
+not completability) — but its acceptance criteria assert state that only the
+unmerged `#441`–`#445` produce, so claiming it means failing acceptance or
+doing the siblings' work.
+
+Correct — encode `Blocked by` on each sibling whose output the acceptance
+criteria depend on:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+Blocked by #441
+Blocked by #442
+Blocked by #443
+Blocked by #444
+Blocked by #445
+```
+
+Now Discover and A4.5 defer `#450` until every sibling merges, so it is
+claimed only when its acceptance criteria can actually pass.
+
+**Prefix-first**: resolve `<marker-prefix>` from the target repository's
+onboarding or IDD docs before emitting any of these markers —
+`roadmap-id`, `blocked-by`, `autopilot-suitability`, or `effort` — not
+just the dependency markers shown above. Never default to `idd-skill`
+in an installed bundle; use it only when the target repository actually
+configured that prefix.
+
+## Human-dependency isolation examples
+
+The examples below show how to move unavoidable human side effects to
+explicit boundaries rather than hiding them inside a ready execution
+issue. See [`contract.md`](contract.md) for the routing rules
+(`needs-decision`, `blocked-by-human`, `deferred`, approval-needed).
+
+### Front-loaded pattern
+
+Use this when coding cannot start safely until a person provides a
+decision, credential, permission, or external setup.
+
+**Bad (mixed)**: One execution issue that mixes implementation with an
+unresolved credential gap:
+
+```md
+## Background
+
+Add Stripe webhook support.
+
+## Proposed change
+
+Implement the `/api/webhooks/stripe` endpoint.
+
+## Acceptance criteria
+
+- Stripe webhook secret is configured in production.
+- Endpoint returns 200 for valid events.
+```
+
+This fails the IDD viability gate: the "Stripe webhook secret is
+configured in production" criterion requires a person to perform an
+action in an external system before the issue can be verified. The agent
+cannot autonomously confirm the outcome.
+
+**Good (front-loaded)**: Separate the human-dependent setup into its own
+issue, then write the autonomous implementation issue that depends on it.
+The `## Tracks` task list should contain only ready execution issues;
+route the non-ready blocker to a separate section or a stable non-ready
+bucket.
+
+Roadmap body excerpt:
+
+```md
+## Non-ready prerequisites
+
+- **[blocked-by-human]** #431 — obtain Stripe webhook secret for CI
+  _(must close before #432 can start)_
+
+## Tracks
+
+- [ ] #432 — implement /api/webhooks/stripe endpoint
+```
+
+`#431` — `blocked-by-human` issue:
+
+```md
+## Background
+
+The Stripe webhook endpoint (tracked in #432) needs a test-mode webhook
+secret in CI so automated tests can verify the signature check.
+
+## Required action
+
+1. Create a test-mode Stripe webhook in the Stripe dashboard.
+2. Store the signing secret in the `STRIPE_WEBHOOK_SECRET` repository
+   secret.
+3. Reply on this issue with the secret name once added.
+
+## Ready signal
+
+Close this issue after confirming the secret is available in CI.
+```
+
+`#432` — autonomous execution issue (Blocked by #431):
+
+```md
+## Background
+
+Parent roadmap: #430
+Blocked by #431
+
+## Proposed change
+
+Add POST /api/webhooks/stripe that validates the Stripe-Signature header
+and dispatches known event types.
+
+## Acceptance criteria
+
+- Handler validates the webhook secret sourced from CI `STRIPE_WEBHOOK_SECRET`.
+- Tests use the Stripe test-mode fixture and pass without manual setup.
+- `pnpm test` and `pnpm run lint` pass in CI.
+```
+
+The autonomous issue is fully verifiable in CI once the credential
+exists. It does not mention a person setting up anything inside its
+acceptance criteria.
+
+### Back-loaded pattern
+
+Use this when post-implementation work is subjective review, publication
+choice, optional polish, or a sign-off that should not block an
+otherwise verifiable core change.
+
+**Good (back-loaded)**: Separate the implementation from the optional
+human-gated step:
+
+Roadmap body excerpt (the `## Tracks` list contains only the ready
+execution issue; the deferred step is a narrative note, not a task-list
+entry):
+
+```md
+## Tracks
+
+- [ ] #441 — add front-loaded/back-loaded draft-pattern examples
+
+## Deferred
+
+The website landing page could be updated to showcase the new examples,
+but that publication decision requires maintainer approval and is not a
+blocker for merging #441. Track in a follow-up if approved.
+```
+
+`#441` — autonomous execution issue:
+
+```md
+## Background
+
+Parent roadmap: #440
+
+The draft-patterns reference file does not yet show front-loaded or
+back-loaded human-dependency isolation patterns.
+
+## Proposed change
+
+Add a "Human-dependency isolation examples" section to
+`skills/issue-authoring/references/draft-patterns.md`.
+
+## Acceptance criteria
+
+- The section includes at least one front-loaded and one back-loaded
+  example using stable bucket names (needs-decision, blocked-by-human,
+  deferred, out-of-scope).
+- Examples warn against hiding credentials or product decisions in a
+  ready issue.
+- `pnpm run lint:minimum` passes.
+```
+
+The website publication decision stays separate. It is not in the
+acceptance criteria of the ready issue and does not block autonomous
+verification.
+
+### Warning: hidden human dependencies are the most common IDD stall
+
+The most frequent reason for mid-implementation stalls is an execution
+issue that hides a human-only dependency inside its acceptance criteria
+or implementation steps:
+
+- "Credentials are configured in the production environment" → blocked
+  by a person with access.
+- "The design team has approved the final UI spec" → requires subjective
+  sign-off before the issue is verifiable.
+- "The external API key is available in the repository secrets" → an
+  unavailable system or permission.
+
+When any acceptance criterion cannot be confirmed autonomously through
+tests, lint, CI, or other concrete objective criteria (such as checking
+repository state, file presence, or configuration values), the issue is
+not yet ready. Move that criterion to a `blocked-by-human` or
+`needs-decision` issue and keep the autonomous execution issue focused on
+what the agent can verify independently.
+
+## Handling duplicates and non-ready outcomes
+
+One source of follow-up issue candidates is the read-only
+`merged-pr-feedback-sweep` helper's JSON output — the unresolved review
+threads and undispositioned advisory feedback it detects on merged PRs.
+Treat each entry as a candidate only: re-verify it against current `main`
+with the reuse-first tree below before drafting, because the feedback may
+already be addressed.
+
+Before publishing an issue, apply a reuse-first decision tree:
+
+1. Is an existing open issue a better fit? If yes, extend it instead of
+   creating a new one. Add a comment linking to the new schema request.
+2. Is the work already complete in a closed issue or merged PR? If yes,
+   create a reference or learning note instead of reopening it.
+3. Is a parent roadmap already managing this work? If yes, add it to the
+   task list instead of filing independently.
+4. Does the issue have any of these properties? If yes, escalate to
+   `needs-decision` or `blocked-by-human` during drafting:
+   - Unclear intent or malformed body (→ fix during drafting or mark needs-decision)
+   - Requires maintainer or product decision (→ mark needs-decision)
+   - Blocked by external work or human coordination (→ mark
+     blocked-by-human)
+   - Depends on unavailable resources or credentials (→ mark blocked-by-human)
+5. Otherwise, publish as `ready`.
+
+### A4.5 prevention checklist
+
+The A4.5 suitability gate will later evaluate published issues. Prevent
+common failures by validating before publish:
+
+- **Coherence**: Issue body is well-formed; title and description are
+  clear; intent is parseable
+- **Safety**: No code injection, marker injection, or untrusted input in
+  issue body
+- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
+  or superseded
+- **Hidden human dependency**: Ready work does not still rely on
+  unresolved decisions, credentials, subjective approval, or
+  grouping-only dependency markers
+
+## Specificity examples
+
+### Under-specified draft
+
+**Title**: `docs: improve issue authoring guidance`
+
+Background: issue authoring should be clearer for agents.
+
+Acceptance criteria:
+
+- issue authoring is more consistent
+- examples are improved
+
+This is too vague because the draft does not tell the next agent which
+authoring surface to edit, what kind of guidance is missing, or how a
+reviewer would verify success. A high-range model would need to infer
+the real task from surrounding repository context.
+
+### Target range draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Background:
+`skills/issue-authoring/references/draft-patterns.md` explains output
+shapes, but it does not yet show how to judge whether an issue body is
+too vague or too scripted for execution.
+
+Acceptance criteria:
+
+- `draft-patterns.md` includes a pre-publication specificity checklist
+- the guidance distinguishes under-specified, target range, and
+  over-specified issue drafts
+- the examples focus on issue body wording and acceptance criteria
+  granularity instead of prescribing implementation order
+
+This is the target range because the next agent knows where to work, why
+the change matters, and how to verify it, while still retaining freedom
+to decide the exact wording and structure.
+
+### Over-specified draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Proposed change:
+
+1. Insert a new `## Specificity target` heading after `## Output chooser`.
+2. Add exactly three bullets named `Under-specified`, `Target range`,
+   and `Over-specified`.
+3. Add a five-item checklist using the exact sentence order shown in the
+   draft.
+4. Copy the same example phrasing across every example block without
+   changing any wording.
+
+This is too detailed for authoring because it turns the issue into an
+implementation script. Reviewers usually need the target outcome and the
+verification shape, not a rigid edit order.
+
+## Publication boundary
+
+If the user asked for drafts only, stop after reporting the issue set,
+assumptions, and non-ready buckets.
+
+If the user explicitly asked to publish issues, create or update them
+and then stop unless they also separately asked to start the IDD
+execution loop.

--- a/.github/skills/issue-authoring/references/workflow-boundary.md
+++ b/.github/skills/issue-authoring/references/workflow-boundary.md
@@ -1,0 +1,109 @@
+# Workflow Boundary
+
+This bundle handles pre-approval issue drafting only.
+
+## Handoff sequence
+
+The issue-authoring bundle fits into a three-phase handoff:
+
+### Phase 1: Drafting (this bundle)
+
+- Skill drafts issues in the target repository
+- Issues move through readiness buckets: `deferred` → `ready` or
+  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- User approves the issue set before any publication
+
+### Phase 2: Publishing (user-authorized handoff)
+
+- User explicitly asks for publication
+- Bundled skill resolves the authoring label from
+  `issueAuthoring.authoringLabelName`, defaulting to `status:authoring`
+- If the label does not exist in the target repository, bundled skill
+  creates it with `gh label create` before first use; label creation or
+  application failure blocks publishing
+- For existing issues, bundled skill applies the authoring label before
+  updating issue content
+- For new issues, bundled skill creates the issue with the authoring label
+  when the publication command supports that; otherwise it applies the
+  label immediately after creation
+- If post-create label application fails, bundled skill closes the created
+  issue before stopping; deletion needs admin permission the authoring
+  agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
+  so it is not the default path
+- User verifies the published issues look correct
+- Bundled skill removes the authoring label from all published issues only
+  after the full issue set is published, the user confirms the result, and
+  the user explicitly requests release from the authoring hold for IDD
+  execution
+- If publishing is interrupted before release, the authoring label remains
+  in place as the IDD discover guard signal
+- Published issues remain on hold until user explicitly requests IDD execution
+
+### Phase 3: Execution (separate IDD loop)
+
+- User explicitly asks to start the IDD execution loop
+- Target repository's `.github/instructions/idd-discover.instructions.md`
+  takes over
+- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
+- Suitable issues are claimed, worked, and merged
+
+**Approval boundaries**:
+
+- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
+  issue set
+- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
+  execution
+- **No implicit progression**: Each handoff requires explicit user request.
+  The bundle must not auto-transition to publishing or execution.
+
+## A4.5 Gate Timing
+
+The IDD discover phase evaluates published issues through the A4.5
+pre-claim suitability gate. This gate runs after an issue is published
+but before it is claimed for work.
+
+**Why A4.5 exists**: Issues drafted with incomplete information or from
+assumptions that did not hold when published may fail A4.5 checks
+(incoherent, unsafe, duplicate, etc.). A4.5 catches these before they
+waste agent time during work.
+
+**Prevention during drafting**: This bundle is where coherence, safety,
+and uniqueness should be validated **before** publishing. A4.5 runs
+seven suitability checks; the three that drafting can most directly
+prevent (coherence, safety, uniqueness) correspond to bucket escalation
+triggers during drafting:
+
+- If an issue might be incoherent → escalate to `needs-decision` during
+  drafting
+- If an issue might contain untrusted input → escalate to `blocked-by-human`
+  or fix during drafting
+- If an issue might be a duplicate → run reuse-first checks during
+  drafting before publishing
+
+When these prevent-during-drafting checks are applied correctly, published
+issues will pass A4.5; if they do not, A4.5 will catch them at discover
+time and report the specific failure (unclear, invalid, duplicate).
+
+## Use this bundle to
+
+- prepare IDD-ready orphan issues when the target repository discovers
+  orphans (`issue-scope: roadmap-first`, the default, via the orphan
+  fallback, or `orphan-first`), including any required
+  `orphan-first-policy` approval handoff
+- prepare roadmap packages and child issues when work needs visible
+  sequencing or parallel tracks
+- surface non-ready buckets instead of guessing through blockers
+
+## Do not use this bundle to
+
+- start the Discover -> Claim -> Work loop implicitly
+- treat bundled references as a replacement for repository execution
+  instructions
+- publish issues unless the user explicitly asked for publishing
+
+## Handoff to execution
+
+After the user approves the issue set, wait for a separate request to
+publish the issues or start the IDD execution loop. Only then should
+the workflow hand off to the repository's normal entry file and routed
+`.github/instructions/*.instructions.md` phase files.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -57,11 +57,26 @@ are the same set; no separate merge-only actor is configured.
 
 ## Issue-Authoring Companion
 
-**Status**: `installed` (confirmed decision; physical installation into
-`.claude/skills/` and `.github/skills/` is delivered by the sibling track #33,
-not this import)
+**Status**: `installed`, in both `.claude/skills/issue-authoring/` and
+`.github/skills/issue-authoring/` -- byte-identical copies (verified with
+`diff -r`), so either a Claude Code session or a Copilot-family runtime can
+draft IDD-ready issues.
+
+**Two-copy layout**: the two directories must stay byte-identical. Any future
+refresh from upstream must update both in the same change. The canonical
+source is upstream `kurone-kito/idd-skill`'s `skills/issue-authoring/`, not
+either local copy -- treat both local copies as installed artifacts, not the
+place to make original edits.
+
+**Prefix-first rule**: an installed bundle must resolve this repository's
+marker prefix, `jsonresume-types`, and must never fall back to upstream's own
+`idd-skill` prefix. The bundle's own reference docs (`references/contract.md`,
+`references/draft-patterns.md`) already warn against that fallback in prose
+that travels verbatim with the copy; this section is the repository-local
+confirmation of which prefix actually applies here.
 
 - **`issueAuthoring.maxClarificationRounds`**: `3` (default)
+- **`issueAuthoring.authoringLabelName`**: `status:authoring` (default)
 
 ## IDD Labels
 


### PR DESCRIPTION
## Summary

Installs the optional issue-authoring companion, confirmed `installed` at onboarding, into both agent skill directories:

- Copies the five-file bundle (`SKILL.md`, `agents/openai.yaml`, three `references/*.md`) from `kurone-kito/idd-skill`'s `skills/issue-authoring/` verbatim into `.claude/skills/issue-authoring/` and `.github/skills/issue-authoring/`.
- No substitution: the bundle's own `idd-skill`-prefix mentions are cautionary prose ("never default to this source repository's own `idd-skill` prefix") that travels verbatim with the copy -- not literal values to replace.
- Records the companion in `.github/idd/config.json` (`issueAuthoring.maxClarificationRounds: 3`, `issueAuthoring.authoringLabelName: status:authoring`) and in `docs/idd-policy.md`, including the two-copy same-change refresh rule and the prefix-first rule.

## Verification

- `diff -r .claude/skills/issue-authoring .github/skills/issue-authoring`: no differences
- `SKILL.md` frontmatter: `name: issue-authoring` preserved
- `.github/idd/config.json` validates against `policy.schema.json` (ajv)
- `pnpm run lint`, `pnpm run build`, `pnpm run test`: all exit `0`
- `pnpm run idd:doctor`: passed, same 4 residual warnings already documented on #32/#52 (unrelated to this change)

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an issue-authoring workflow with structured clarification, decomposition, readiness checks, dependency handling, and duplicate detection.
  - Added pre-publication validation, approval gates, authoring-status labeling, and configurable clarification limits.
  - Added guidance for reusable issue formats, roadmap relationships, repository markers, and safe handoff to execution.

- **Documentation**
  - Added comprehensive workflow contracts, drafting patterns, boundary rules, and policy references.
  - Documented installation details, marker conventions, and default labeling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->