### PR TITLE
feat(idd): enable the local worktree guard hooks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -253,6 +253,17 @@ if `index.d.ts` is stale or missing.
 pnpm run clean
 ```
 
+### Wiring the IDD worktree guard
+
+```sh
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/pre-push
+```
+
+`core.hooksPath` is local and does not survive a fresh clone, so re-run
+this at the start of every task rather than assuming a previous
+session's local config is still in effect.
+
 ## Testing strategy
 
 - **What "test" verifies**: that the schema-generated `index.d.ts`

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -34,5 +34,8 @@
   },
   "autopilotSuitability": {
     "floor": 3
+  },
+  "worktreeGuard": {
+    "enabled": true
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ immediately, without depending on a redirect.
 - Lint and auto-fix: `pnpm run lint:fix`
 - Test (type-checks the generated `index.d.ts`): `pnpm run test`
 - Clean: `pnpm run clean`
+- Wire the IDD worktree guard (re-run at the start of every task --
+  `core.hooksPath` is local and does not survive a fresh clone):
+  `git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push`
 
 ## Immediate rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ rules immediately, without depending on a redirect.
 - Lint and auto-fix: `pnpm run lint:fix`
 - Test (type-checks the generated `index.d.ts`): `pnpm run test`
 - Clean: `pnpm run clean`
+- Wire the IDD worktree guard (re-run at the start of every task --
+  `core.hooksPath` is local and does not survive a fresh clone):
+  `git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push`
 
 ## Immediate rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,9 @@ rules immediately, without depending on a redirect.
 - Lint and auto-fix: `pnpm run lint:fix`
 - Test (type-checks the generated `index.d.ts`): `pnpm run test`
 - Clean: `pnpm run clean`
+- Wire the IDD worktree guard (re-run at the start of every task --
+  `core.hooksPath` is local and does not survive a fresh clone):
+  `git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push`
 
 ## Immediate rules
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -78,6 +78,46 @@ confirmation of which prefix actually applies here.
 - **`issueAuthoring.maxClarificationRounds`**: `3` (default)
 - **`issueAuthoring.authoringLabelName`**: `status:authoring` (default)
 
+## Worktree Guard
+
+**Status**: `worktreeGuard.enabled: true`. The `.githooks/pre-commit` and
+`.githooks/pre-push` hooks refuse a commit or push made from the **primary**
+worktree while HEAD is on an implementation branch (`issue/*` or
+`roadmap-audit/*`) -- B1 requires that work to live in a sibling worktree.
+
+**One-time local wiring** (per clone -- `core.hooksPath` is local and
+uncommitted):
+
+```sh
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/pre-push
+```
+
+**Fresh-clone caveat**: `worktreeGuard.enabled: true` alone enforces nothing.
+A coding agent, ephemeral container, or throwaway checkout starts unwired and
+silently unguarded until the command above runs. Re-run it at the start of
+every task rather than assuming a previous session's local config survived.
+
+**Enabled-but-inert finding**: `idd-doctor` reports this specific finding when
+`worktreeGuard.enabled` is `true` but `core.hooksPath` is not pointed at
+`.githooks` in the current checkout. That finding is the signal the setup
+step above did not run -- not a false positive to suppress. In practice this
+is the common steady state: `core.hooksPath` also drives this repository's
+Husky-managed `lint-staged`/`commitlint` hooks (`.husky/pre-commit`,
+`.husky/commit-msg`), and `pnpm install`'s `prepare` script resets
+`core.hooksPath` back to Husky's directory on every install. Wiring the
+worktree guard therefore trades away Husky's git-level enforcement for the
+duration it stays wired; re-running `pnpm install` (or the wiring command
+again after it) switches `core.hooksPath` back. Neither this repository nor
+upstream `idd-skill` (which also ships `worktreeGuard.enabled: true` but
+keeps `core.hooksPath` on Husky day to day) resolves this tension by chaining
+the two hook sets -- treat the worktree guard as a manually-invoked check
+around worktree-sensitive operations, not a permanently co-resident hook.
+
+**Intentional bypass**: `--no-verify` on `git commit` / `git push` is the
+single-commit escape hatch for a deliberate exception, so it should never be
+mistaken for a broken hook.
+
 ## IDD Labels
 
 Distributed defaults: `roadmap`, `status:blocked-by-human`,


### PR DESCRIPTION
## Summary

Activates the disposable-worktree guard the import track (#32) shipped inert:

- `worktreeGuard.enabled: true` in `.github/idd/config.json`.
- Documents the one-time local wiring (`git config core.hooksPath .githooks`, executable bits already `100755` on both hook files) in `docs/idd-policy.md`.
- Adds the same wiring command to `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and `.github/copilot-instructions.md` as a setup-command line, with the fresh-clone caveat.

## Guard behavior, verified live

With `core.hooksPath` pointed at `.githooks` and the config change from this branch overlaid onto the primary worktree's working tree:

- **Primary worktree, HEAD on `issue/999-guard-smoke`**: `git commit` refused, exit `1`:
  ```
  IDD worktree guard: refusing to commit on "issue/999-guard-smoke" from the primary worktree (.../jsonresume-types).
  B1 requires implementation branches to live in a sibling worktree, not the primary worktree.
  Create one, e.g.:  git worktree add ../<repo>.issue-999-guard-smoke issue/999-guard-smoke
  See B1 in .github/instructions/idd-work.instructions.md.
  (To bypass intentionally, re-run the git command with --no-verify.)
  ```
- **Linked worktree (this branch's own sibling worktree), HEAD on `issue/34-...`**: the same shape of commit succeeded normally, exit `0`.

Both worktrees were returned to their prior state afterward: primary worktree back on `main` with the smoke branch deleted, `core.hooksPath` restored to Husky's directory.

## A discovered, previously-undocumented interaction

`core.hooksPath` also drives this repository's Husky-managed `lint-staged`/`commitlint` hooks (`.husky/pre-commit`, `.husky/commit-msg`), and `pnpm install`'s `prepare` script resets it back to Husky's directory on every install. Wiring the worktree guard therefore trades away Husky's git-level enforcement for as long as it stays wired. Neither this repository nor upstream `kurone-kito/idd-skill` -- which also ships `worktreeGuard.enabled: true` but keeps `core.hooksPath` on Husky day to day -- resolves this by chaining the two hook sets. `idd-doctor`'s "enabled-but-inert" finding (confirmed present on this branch: `worktreeGuard.enabled is true but the commit/push guard is not active in this environment`) is the expected steady state here, not a defect this issue needs to eliminate -- documented as such in `docs/idd-policy.md` rather than left as a silent surprise.

## Verification

- `.github/idd/config.json` validates against `policy.schema.json` (ajv)
- `pnpm run lint`, `pnpm run build`, `pnpm run test`: all exit `0`
- `pnpm run idd:doctor`: passed, 5 warnings (the new enabled-but-inert finding plus the 4 already documented on #32/#33/#52)

Closes #34