### PR TITLE
ci(idd): add the idd-doctor health gate and the advisory-convergence check

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,0 +1,49 @@
+name: IDD advisory-convergence gate
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to re-check (e.g. after posting a maintainer waiver)
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+jobs:
+  idd-advisory-convergence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Stages the trusted default branch
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version-file: .node-version
+      - env:
+          HUSKY: 0
+        name: Install the dependencies
+        run: pnpm install --frozen-lockfile
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        name: Run the advisory-convergence check
+        run: pnpm run idd:advisory-convergence --pr "$PR_NUMBER" --assert

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          cache: pnpm
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
           node-version-file: .node-version
       - env:
           HUSKY: 0

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -1,0 +1,34 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+name: IDD doctor health gate
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Stages the pushed branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version-file: .node-version
+      - env:
+          HUSKY: 0
+        name: Install the dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run the idd-doctor repository-health check
+        run: pnpm run idd:doctor

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          cache: pnpm
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
           node-version-file: .node-version
       - env:
           HUSKY: 0


### PR DESCRIPTION
## Summary

Adds the two optional IDD CI gates the onboarding interview opted into. Neither is wired in by importing the template -- adding a status-check-able workflow is a deliberate adopter decision.

**`.github/workflows/idd-doctor.yml`**: `pull_request`-triggered (not a `push` filter -- IDD branches are slash-namespaced), checks out `${{ github.sha }}` with `fetch-depth: 0` and `persist-credentials: false`, installs via the `package-manager` profile, runs `pnpm run idd:doctor`.

**`.github/workflows/idd-advisory-convergence.yml`**, adapted from upstream's mirrored copy:
- all four triggers, including `workflow_dispatch`'s `pr_number` input
- checkout pinned to the trusted `main` branch (not the PR head -- a PR must not be able to edit the verdict logic itself)
- `contents: read`, `pull-requests: read`, `issues: read`
- invokes `idd:advisory-convergence` (the `package-manager` profile's script entry), not the mirrored file's `node scripts/...` form

Registering the check as **required** in branch protection is a maintainer GitHub-settings action, tracked separately -- this issue only hosts the workflow.

## Verification

- `actionlint` on both files: clean
- `pnpm run idd:doctor` locally: passed, 5 known warnings (same set as #34)
- `pnpm run idd:advisory-convergence --pr 60 --assert` against a real merged PR: exits `0`
- `pnpm run lint`, `pnpm run build`, `pnpm run test`: all exit `0`
- Both workflows will trigger on this PR itself, opened from `issue/35-ci-idd-add-idd-doctor-health-gate` -- watch the checks below for the live proof

Closes #35