### PR TITLE
chore(idd): register idd-advisory-convergence as a required status check

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -20,6 +20,7 @@ words:
   - pytest
   - qwen
   - toctou
+  - unconverged
   - undispositioned
   - unioned
   - unpushed

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -123,16 +123,23 @@ mistaken for a broken hook.
 **Status**: registered. `idd-advisory-convergence` is a required status check
 on the default branch's classic branch protection
 (`strict: true`, `enforce_admins: true` -- the check applies to admin merges
-too, including a trusted merge-capable session's own). Verify with:
+too, including a trusted merge-capable session's own). Verify both together
+with:
 
 ```sh
-gh api repos/kurone-kito/jsonresume-types/branches/main/protection/required_status_checks
+gh api repos/kurone-kito/jsonresume-types/branches/main/protection \
+  --jq '{strict: .required_status_checks.strict, enforce_admins: .enforce_admins.enabled, contexts: .required_status_checks.contexts}'
 ```
+
+(The narrower `.../protection/required_status_checks` endpoint only reports
+`strict` and `contexts`; it omits `enforce_admins`.)
 
 Two behaviors to expect, both by design:
 
 - The check **shows as failing** until the advisory reviewer reviews the
-  current HEAD -- GitHub Actions has no non-failing "pending" state.
+  current HEAD. The workflow's own script always exits pass or fail -- it has
+  no separate pending outcome -- so the check stays red rather than sitting
+  in an in-progress state until convergence.
 - A stale review (one that predates the current HEAD, e.g. after a
   force-push-free follow-up commit) reads as unconverged, not merely
   outdated; re-request review or push a change that prompts a fresh one.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -118,6 +118,32 @@ around worktree-sensitive operations, not a permanently co-resident hook.
 single-commit escape hatch for a deliberate exception, so it should never be
 mistaken for a broken hook.
 
+## Advisory-Convergence Required Check
+
+**Status**: registered. `idd-advisory-convergence` is a required status check
+on the default branch's classic branch protection
+(`strict: true`, `enforce_admins: true` -- the check applies to admin merges
+too, including a trusted merge-capable session's own). Verify with:
+
+```sh
+gh api repos/kurone-kito/jsonresume-types/branches/main/protection/required_status_checks
+```
+
+Two behaviors to expect, both by design:
+
+- The check **shows as failing** until the advisory reviewer reviews the
+  current HEAD -- GitHub Actions has no non-failing "pending" state.
+- A stale review (one that predates the current HEAD, e.g. after a
+  force-push-free follow-up commit) reads as unconverged, not merely
+  outdated; re-request review or push a change that prompts a fresh one.
+
+**Waiver mode**: intentionally left off. `ciGate.externalCheckWaivers.mode`
+is unset in `.github/idd/config.json`, and `idd-advisory-convergence` is not
+listed under `ciGate.externalChecks.waivable`. A stuck advisory-convergence
+check therefore has no maintainer-waiver escape path -- the only way through
+is a fresh converged review. Revisit this decision if the `24h` default
+`advisoryWait.convergenceDeadline` proves too tight in practice.
+
 ## IDD Labels
 
 Distributed defaults: `roadmap`, `status:blocked-by-human`,


### PR DESCRIPTION
## Summary

Registers `idd-advisory-convergence` in the default branch's classic branch protection as a required status check (`strict: true`), closing the gap where a PR could merge before the advisory reviewer converged on the current HEAD -- the gap that matters most under `fully_autonomous_merge`.

Done directly by this session (GitHub Settings action, requires admin) under repository-owner instruction in conversation -- the same maintainer-only override class as #28, and #36's own bootstrap note. `enforce_admins` stays `true`, so the check applies to a trusted merge-capable session's own merges too (including this one).

**Waiver mode: intentionally left off**, per explicit operator decision. `ciGate.externalCheckWaivers.mode` stays unset in `.github/idd/config.json`, and `idd-advisory-convergence` is not added to `ciGate.externalChecks.waivable`. A stuck check therefore has no maintainer-waiver escape path -- only a fresh converged review clears it.

## Verification

- `gh api repos/kurone-kito/jsonresume-types/branches/main/protection/required_status_checks` shows `{"contexts":["idd-advisory-convergence"],"strict":true}`
- `docs/idd-policy.md` records both the registration and the waiver-mode decision
- `pnpm run lint`, `pnpm run build`, `pnpm run test`: all exit `0`
- This PR is itself the live test of the second acceptance criterion (a PR whose advisory review has not converged is blocked from merging) -- it will show as failing until Copilot's review actually converges on the current HEAD, and this session will wait for that rather than merge around it

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the required advisory-convergence status check and its branch-protection requirements.
  - Clarified review, stale-review, waiver, and maintainer bypass behavior.

- **Chores**
  - Added “unconverged” to the spell-check dictionary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->