### PR TITLE
test(idd): verify the completed IDD import against the ONBOARDING Step 6 checklist

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -151,6 +151,35 @@ check therefore has no maintainer-waiver escape path -- the only way through
 is a fresh converged review. Revisit this decision if the `24h` default
 `advisoryWait.convergenceDeadline` proves too tight in practice.
 
+## Known `idd-doctor` Warnings
+
+`idd-doctor --strict` reports these findings as of the #37 import
+verification pass, each an intentional, explained divergence rather than an
+unresolved defect:
+
+- **`review policy signal not found in docs or entry files`** -- upstream
+  check bug, not a real gap. `idd-doctor.mts` searches the corpus for the
+  literal string `'copilot advisory'` (a space) instead of `'copilot-advisory'`
+  (a hyphen, the actual policy vocabulary used everywhere else, including this
+  document's own [PR Review Policy](#pr-review-policy) section and
+  `.github/idd/config.json`'s `reviewPolicy` field). The check can never match
+  as currently written; it is not this repository's job to carry a local
+  patch for an upstream script bug.
+- **`post-merge cleanup backlog`** -- predates the IDD import. The PRs the
+  warning lists (#47-#62) merged before the F4 cleanup-evidence marker
+  convention existed in this repository (before #32), so none of them carry
+  it. This repository does not run the optional server-side
+  `post-merge-cleanup.yml` workflow (upstream ships it only in the
+  `idd-skill` source repository itself, not the distributed template), so
+  the marker is posted only when an agent runs F4 manually going forward.
+  The backlog will not grow further; it will not shrink retroactively either
+  unless someone runs `idd-audit-pr-cleanup --pr <N> --apply --skip-claim-check`
+  against each listed PR.
+- **`release-tag drift`** -- out of scope for the IDD import. Cutting a new
+  release is roadmap #46's concern (`Roadmap: restore the release pipeline
+  and the package's quality gates`), not #38's. This document does not track
+  release cadence.
+
 ## IDD Labels
 
 Distributed defaults: `roadmap`, `status:blocked-by-human`,

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -158,13 +158,18 @@ verification pass, each an intentional, explained divergence rather than an
 unresolved defect:
 
 - **`review policy signal not found in docs or entry files`** -- upstream
-  check bug, not a real gap. `idd-doctor.mts` searches the corpus for the
-  literal string `'copilot advisory'` (a space) instead of `'copilot-advisory'`
-  (a hyphen, the actual policy vocabulary used everywhere else, including this
-  document's own [PR Review Policy](#pr-review-policy) section and
-  `.github/idd/config.json`'s `reviewPolicy` field). The check can never match
-  as currently written; it is not this repository's job to carry a local
-  patch for an upstream script bug.
+  check bug, not a real gap. `idd-doctor.mts`'s review-policy-signal check
+  does a plain corpus substring search for one of five literal signal
+  strings. One of those five is this repository's own review-profile name,
+  but space-joined instead of hyphenated the way the actual policy
+  vocabulary is written everywhere else -- this document's own
+  [PR Review Policy](#pr-review-policy) section above and
+  `.github/idd/config.json`'s `reviewPolicy` field both use the hyphenated
+  form. That one-character difference is why the check fails to match; it is
+  not this repository's job to carry a local patch for an upstream script
+  bug. (Deliberately not spelling out the exact space-joined search string
+  in this note: doing so would make this very sentence satisfy the buggy
+  search, which is the wrong reason for the warning to disappear.)
 - **`post-merge cleanup backlog`** -- predates the IDD import. The PRs the
   warning lists (#47-#62) merged before the F4 cleanup-evidence marker
   convention existed in this repository (before #32), so none of them carry


### PR DESCRIPTION
## Executed through this repository's own local instructions

This issue was executed through this repository's own \`.github/instructions/\` files, not the upstream \`idd-skill\` clone -- a local run reaching merge is the end-to-end proof that the bootstrap dependency is gone.

## Step 6 checklist, item by item

- [x] **Every core execution file, supporting doc, and profile artifact listed in Step 2 is present.** \`idd-onboard.mjs --verify\`: \`manifestCompleteness: {missingSource: [], missingTarget: []}\`.
- [x] **PR review profile recorded, non-default artifacts complete.** \`copilot-advisory\` (distributed default) -- no profile artifact edits needed, per \`docs/idd-policy.md\` § PR Review Policy.
- [x] **Review-thread resolution policy and critique-loop profile recorded.** \`fast-agent-resolve\` and distributed defaults, both default values -- no phase-file customization needed.
- [x] **CI wait / merge policy / credential scope / claim timing / issue-author approval gate / maintainer approval actor policy / helper runtime profile all explicitly recorded.** All present in \`docs/idd-policy.md\`, each with its own section.
- [x] **Issue-authoring companion files present** (operator opted in). \`.claude/skills/issue-authoring/\` and \`.github/skills/issue-authoring/\`, byte-identical (#33).
- [x] **No \`{{...}}\` placeholders; Project commands table correct; orphan-first scope has a valid value.** \`grep -rn '{{[A-Z_]*}}' .github docs profiles .claude\`: no matches. Project commands table in \`idd-overview-core.instructions.md\` resolves to this repo's real pnpm commands. \`orphanFirstPolicy: "none"\` (valid).
- [x] **\`idd-overview-core.instructions.md\` frontmatter intact.** \`applyTo: "**"\`, \`excludeAgent: "code-review"\`, both present.
- [x] **\`CLAUDE.md\`, \`AGENTS.md\`, \`GEMINI.md\` exist and reference \`docs/idd-workflow.md\`.** Confirmed via \`idd-doctor\`'s own three PASS lines for this.
- [x] **Entry files agree on repository-specific engineering guidance (manual check).** Diffed \`CLAUDE.md\`/\`AGENTS.md\`/\`GEMINI.md\` against each other with only the agent name substituted: the only differences are the intentional per-agent wording (e.g. AGENTS.md's Codex/OpenCode-specific IDD Workflow paragraph). Setup commands, Immediate rules, Boundaries, Project standards, and Commit rules sections are otherwise identical. Spot-checked \`.github/copilot-instructions.md\` carries the same facts (\`index.d.ts\` non-commit rule, pnpm commands, \`docs/idd-workflow.md\` reference, \`core.hooksPath\` wiring).
- [x] **\`.github/copilot-instructions.md\` existed before onboarding and now includes the IDD workflow reference.** It existed since #29; #32 added its \`## IDD Workflow\` section.
- [x] **\`{{PROJECT_MARKER_PREFIX}}-roadmap-id\`/\`-blocked-by\` marker names match the prefix; \`config.json\` stays aligned.** \`markerPrefix: "jsonresume-types"\` in \`.github/idd/config.json\`; live markers confirmed on #31/#38/#46 (\`<!-- jsonresume-types-roadmap-id: ... -->\`).

## Mechanical checks

- \`idd-onboard.mjs --verify\`: exits \`0\`, \`"blocking": false\`.
- \`idd-doctor --strict\`: \`result: passed (4 warning(s))\`. One warning (\`worktreeGuard\` enabled-but-inert) was already documented in #34's PR. This PR documents the remaining three in \`docs/idd-policy.md\`'s new **Known idd-doctor Warnings** section:
  - \`review policy signal not found\` -- upstream check bug (searches for \`'copilot advisory'\` with a space, not the hyphenated \`copilot-advisory\` this repo actually uses everywhere).
  - \`post-merge cleanup backlog\` -- PRs #47-#62 predate the F4 cleanup-evidence marker convention (before #32); this repo doesn't run the optional server-side cleanup workflow.
  - \`release-tag drift\` -- roadmap #46's concern, not #38's.
- \`.github/idd/config.json\` validates against \`policy.schema.json\` (ajv), and its recorded values match \`docs/idd-policy.md\` field for field (verified while writing every prior track's PR in this roadmap).
- \`pnpm run lint\`, \`pnpm run build\`, \`pnpm run test\`: all exit \`0\`.

Closes #37