### PR TITLE
chore(idd): merge idd-skill v0.6.0's lint-config named gaps

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -12,19 +12,35 @@ words:
   - desync
   - desynced
   - esync
+  - GHEC
+  - GHES
+  - idd
   - isort
+  - kito
+  - kuron
+  - kurone
+  - kuroné
+  - minimizable
+  - ministral
   - npms.io
+  - nvmrc
   - onnx
   - pylint
   - pyproject
   - pytest
   - qwen
+  - rollup
   - toctou
+  - tsfile
   - unconverged
   - undispositioned
   - unioned
+  - unmigrated
+  - unmirrored
   - unpushed
   - unreplied
+  - unrouted
   - unscored
   - unwaived
   - waivable
+  - WHATWG

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,3 +2,4 @@ ignores:
   - '**/node_modules/**/*'
   - .github/CODE_OF_CONDUCT*
   - node_modules/**/*
+  - node_modules/**/*.md

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,1 +1,28 @@
 extends: '@kurone-kito/markdownlint-config'
+# Allow non-aligned table columns. Tables with long cell content are
+# impractical to keep aligned without breaking readability.
+table-column-style: false
+# Allow limit breakthroughs in the code block and table row lengths. The
+# default is unconditional prohibition. It is exceptionally allowed in
+# these elements due to folding difficulties.
+line-length:
+  code_blocks: false
+  headings: false
+  tables: false
+# Allows the use of duplicate headings. The default is unconditional
+# prohibition. Due to the `siblings_only` flag not working, it is necessary
+# to enable duplicate headings in the entire document.
+no-duplicate-heading: false
+# Allows embedding of the specified HTML tag. The default is unconditional
+# prohibition. Allow for some valuable features, such as folding.
+no-inline-html:
+  allowed_elements:
+    - details
+    - summary
+# Stop MD025 from treating an OKF frontmatter `title:` field as a second
+# level-1 heading alongside the page's own `# H1`. The default pattern
+# (`^\s*title\s*[:=]`) matches both, firing
+# `MD025/single-title/single-h1 Multiple top-level headings` on every
+# conforming OKF page.
+single-title:
+  front_matter_title: ''


### PR DESCRIPTION
## Summary

Additively merges `kurone-kito/idd-skill`'s `idd-template@v0.6.0` named
lint-config gaps into this repository's existing
`.cspell.config.yml`, `.markdownlint.yml`, and `.markdownlint-cli2.yaml`,
per `idd-template/ONBOARDING.md`'s "Upgrading from an earlier IDD
version" guidance for repositories that already had their own
same-named files before the template added them.

- `.cspell.config.yml`: keeps `import: ['@kurone-kito/cspell-config']`
  and the `cache:` block unchanged; adds 16 IDD/project-specific
  `words` not already covered (case-insensitively) by the existing
  list. The template's other top-level settings
  (`allowCompoundWords`, `dictionaries`, `enableGlobDot`, `language`,
  `useGitignore`, `ignorePaths`) were checked against
  `@kurone-kito/cspell-config`'s own config and are already supplied
  by that shared preset, so none of them were duplicated locally.
- `.markdownlint.yml`: keeps `extends: '@kurone-kito/markdownlint-config'`
  unchanged; adds the five rule overrides needed for the docs bundle a
  sibling issue will import (OKF frontmatter, wide tables).
- `.markdownlint-cli2.yaml`: merges the template's
  `node_modules/**/*.md` entry into the existing `ignores` list, with
  no duplicates.

`pnpm run lint` passed on `main` before this change and continues to
pass after it — this PR touches only lint configuration, not linted
content.

Closes #65

## Test plan

- [x] `pnpm run lint:fix && pnpm run lint` (fix-validate)
- [x] `pnpm run lint && pnpm run build && pnpm run test` (pre-push-validate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded spelling support for project, tooling, protocol, and domain-specific terminology.
  - Excluded third-party Markdown files from linting.
  - Added Markdown linting rules to accommodate tables, code blocks, headings, inline HTML, duplicate headings, and front matter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->