### PR TITLE
chore(idd): bump the idd-skill pin to v0.6.0 and reconcile config.json

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.4.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "jsonresume-types",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
@@ -30,7 +30,8 @@
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "advisoryWait": {
-    "convergenceScope": "all-prs"
+    "convergenceScope": "all-prs",
+    "exemptBotAuthoredPrs": true
   },
   "autopilotSuitability": {
     "floor": 3

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@kurone-kito/biome-config": "^0.23.0-alpha.1",
     "@kurone-kito/commitlint-config": "^0.23.0-alpha.1",
     "@kurone-kito/cspell-config": "^0.23.0-alpha.1",
-    "@kurone-kito/idd-skill": "github:kurone-kito/idd-skill#f0b59fa5ac33f68753f0d05218bcdfda9dd899b5",
+    "@kurone-kito/idd-skill": "github:kurone-kito/idd-skill#f16660486383ce710a0f33f49aa3331ddece93de",
     "@kurone-kito/lint-staged-config": "^0.23.0-alpha.1",
     "@kurone-kito/markdownlint-config": "^0.23.0-alpha.1",
     "@kurone-kito/typescript-config": "^0.22.0-alpha.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^0.23.0-alpha.1
         version: 0.23.0-alpha.1(cspell@10.0.1)
       '@kurone-kito/idd-skill':
-        specifier: github:kurone-kito/idd-skill#f0b59fa5ac33f68753f0d05218bcdfda9dd899b5
-        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f0b59fa5ac33f68753f0d05218bcdfda9dd899b5
+        specifier: github:kurone-kito/idd-skill#f16660486383ce710a0f33f49aa3331ddece93de
+        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f16660486383ce710a0f33f49aa3331ddece93de
       '@kurone-kito/lint-staged-config':
         specifier: ^0.23.0-alpha.1
         version: 0.23.0-alpha.1(cspell@10.0.1)(lint-staged@17.2.0)
@@ -490,9 +490,9 @@ packages:
       cspell:
         optional: true
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f0b59fa5ac33f68753f0d05218bcdfda9dd899b5':
-    resolution: {gitHosted: true, integrity: sha512-cJrSNwp7JKSKuBYhXorQfySOW4bqEXwS/PIXLzGdziXAIrhwPNXRKsf5MMbUGgcfFSf12AhQWlRFHzbyVqBwgA==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f0b59fa5ac33f68753f0d05218bcdfda9dd899b5}
-    version: 0.4.0
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f16660486383ce710a0f33f49aa3331ddece93de':
+    resolution: {gitHosted: true, integrity: sha512-IEX4zK+KpVdFb4IEMq9/l0qMHNzmiCnbAHXbX93aui/eJDpOUaoFqAmwW0pGSBdfsSTk0RQQBmUtqKrMqHwUsQ==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f16660486383ce710a0f33f49aa3331ddece93de}
+    version: 0.6.0
     engines: {node: ^22.22.2 || >=24.2.0}
     hasBin: true
 
@@ -1789,7 +1789,7 @@ snapshots:
     optionalDependencies:
       cspell: 10.0.1
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f0b59fa5ac33f68753f0d05218bcdfda9dd899b5': {}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f16660486383ce710a0f33f49aa3331ddece93de': {}
 
   '@kurone-kito/lint-staged-config@0.23.0-alpha.1(cspell@10.0.1)(lint-staged@17.2.0)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f0b59fa5ac33f68753f0d05218bcdfda9dd899b5': true
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f16660486383ce710a0f33f49aa3331ddece93de': true
 gitChecks: false
 ignoreWorkspaceRootCheck: true
 linkWorkspacePackages: true


### PR DESCRIPTION
## Summary

Bumps the `@kurone-kito/idd-skill` devDependency pin from a pre-`v0.5.0`
commit to the commit tagged `v0.6.0`, and reconciles
`.github/idd/config.json` with the new version.

- `package.json`: `@kurone-kito/idd-skill` spec changed to
  `github:kurone-kito/idd-skill#f16660486383ce710a0f33f49aa3331ddece93de`.
  That ref is the **annotated tag object** SHA for `refs/tags/v0.6.0`
  (it peels to commit `0a9c90dc277e05e0d7d96f1b09d79ff668860cc6`) —
  confirmed this resolves cleanly via `pnpm install` to
  `@kurone-kito/idd-skill@0.6.0`.
- `pnpm-lock.yaml` regenerated accordingly; `pnpm-workspace.yaml`'s
  `allowBuilds` entry updated to the new SHA's codeload URL (the stale
  old-SHA entry is removed — nothing in the resolved tree references it
  anymore).
- `.github/idd/config.json`: `iddVersion` bumped from `"0.4.0"` to
  `"0.6.0"`; `advisoryWait.exemptBotAuthoredPrs: true` added alongside
  the existing `advisoryWait.convergenceScope: "all-prs"`, exempting
  bot-authored PRs (this repo has active Dependabot PRs with no IDD
  claim-marker history) from needing a manual maintainer waiver under
  the `idd-advisory-convergence` required check. No other config keys
  changed — `helperRuntime.packageSpec` (only relevant to the
  `ephemeral-npx` profile; this repo uses `package-manager`) and
  `ciGate.trustSourcePinnedRequiredChecks` (this repo's only required
  check, `idd-advisory-convergence`, is classic branch protection, not
  a source-pinned/app-`id` ruleset check — confirmed live via
  `gh api repos/kurone-kito/jsonresume-types/branches/main/protection`)
  were deliberately left out, per the issue.

Verified before implementing: the `idd-*` CLI `bin` command set (39
entries) is byte-identical between the old and new pins, and
`schemas/policy.schema.json`'s only non-`description` changes between
the two versions are three new optional fields — so this is a
version bump with no functional/schema-breaking impact for this
repository's usage. `.github/idd/config.json` still validates against
`policy.schema.json` (confirmed via `idd-doctor`).

Closes #66

## Test plan

- [x] `pnpm run lint:fix && pnpm run lint` (fix-validate)
- [x] `pnpm run lint && pnpm run build && pnpm run test` (pre-push-validate)
- [x] `pnpm install` runs clean with no lockfile/workspace-manifest drift
- [x] `.github/idd/config.json` validates against `policy.schema.json` (`idd-doctor`)
