### PR TITLE
ci(idd): refresh idd-advisory-convergence.yml runner override and job-id note

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -23,8 +23,9 @@ jobs:
   # The job id `idd-advisory-convergence` is the literal check-run context
   # consumed by the rerun helper, advisory-wait policy, the required-status-
   # check entry on main's branch-protection Ruleset, and the external-check
-  # waiver selector. Do not rename it or add a `name:` display-name key
-  # without updating every one of those consumers to match.
+  # waiver selector. Do not rename it or add a job-level `name:` key (i.e.
+  # jobs.idd-advisory-convergence.name -- distinct from the workflow-level
+  # `name:` above) without updating every one of those consumers to match.
   idd-advisory-convergence:
     # Falls back to today's ubuntu-latest unless the CI_RUNNER_LABEL
     # repository variable is set (Settings > Secrets and variables >

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -20,8 +20,16 @@ permissions:
   issues: read
   pull-requests: read
 jobs:
+  # The job id `idd-advisory-convergence` is the literal check-run context
+  # consumed by the rerun helper, advisory-wait policy, the required-status-
+  # check entry on main's branch-protection Ruleset, and the external-check
+  # waiver selector. Do not rename it or add a `name:` display-name key
+  # without updating every one of those consumers to match.
   idd-advisory-convergence:
-    runs-on: ubuntu-latest
+    # Falls back to today's ubuntu-latest unless the CI_RUNNER_LABEL
+    # repository variable is set (Settings > Secrets and variables >
+    # Actions > Variables) -- no behavior change until it's configured.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Stages the trusted default branch


### PR DESCRIPTION
## Summary

Refreshes `.github/workflows/idd-advisory-convergence.yml` under the scope amended by the maintainer addendum on #68 (not the original issue body's byte-identical-replacement acceptance criteria, which a B2.1 premise check found would have broken the required `idd-advisory-convergence` check on every run — see the linked comments below for the full verification).

Ports the two genuine `v0.6.0` `idd-skill` deltas onto this repository's existing pnpm-adapted workflow, leaving the toolchain untouched:

- `runs-on: ubuntu-latest` → `runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}` — falls back to today's behavior unless the `CI_RUNNER_LABEL` repository variable is later configured.
- Added a comment above the job id warning against renaming `idd-advisory-convergence` or adding a `name:` display-name key, since it's the literal check-run context consumed by the rerun helper, advisory-wait policy, this repo's branch-protection Ruleset (`required_status_checks`), and the external-check waiver selector.

Untouched: `pnpm/action-setup`, `actions/setup-node` + pnpm caching, `pnpm install --frozen-lockfile`, the `pnpm run idd:advisory-convergence --pr "$PR_NUMBER" --assert` invocation, and every `on:`/`permissions:`/`concurrency:` block. Job id stays exactly `idd-advisory-convergence` — no Ruleset edit needed.

A `GH_ENTERPRISE_TOKEN` item from the original acceptance criteria was dropped: verification found it doesn't exist in the actual `v0.6.0` template, so there was nothing to port.

Closes #68

## Background / rationale

- Hold with full verification evidence (byte-identical fetch method, sha256, and why a literal template replacement breaks CI): https://github.com/kurone-kito/jsonresume-types/issues/68#issuecomment-5268367906
- Maintainer addendum amending the acceptance criteria to this narrower scope: https://github.com/kurone-kito/jsonresume-types/issues/68#issuecomment-5269845010
- B2 implementation plan (critiqued before posting): https://github.com/kurone-kito/jsonresume-types/issues/68#issuecomment-5269910148

## Validation

- `actionlint .github/workflows/idd-advisory-convergence.yml` — no errors
- `pnpm run lint:fix && pnpm run lint` — clean
- `pnpm run lint && pnpm run build && pnpm run test` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow execution can now use a repository-configured runner.
  * Falls back to the standard hosted runner when no custom runner is configured.
  * Added documentation clarifying runner configuration and workflow job requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->