### PR TITLE
ci: add .github/release-drafter.yml adapted from lints-config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+name-template: v$RESOLVED_VERSION 🌈
+tag-template: v$RESOLVED_VERSION
+# Categories and autolabeler targets below must only reference labels
+# this repository actually applies for release notes. IDD's reserved
+# labels (roadmap, status:authoring, status:blocked-by-human,
+# status:needs-decision, idd:ready — see docs/idd-policy.md) must
+# never be added as release-drafter categories or autolabeler targets.
+categories:
+  - title: 💥 Breaking Changes
+    label: breaking
+  - title: 🚀 Features
+    label: enhancement
+  - title: 🐛 Bug Fixes
+    label: bug
+  - title: 📝 Documentation
+    label: documentation
+  - title: 🧰 Maintenance
+    label: dependencies
+    collapse-after: 5
+autolabeler:
+  - label: breaking
+    title:
+      - '/^\w+(\([^)]+\))?!:/'
+    body:
+      - '/BREAKING CHANGE:/'
+  - label: enhancement
+    title:
+      - '/^feat(\([^)]+\))?!?:/'
+  - label: bug
+    title:
+      - '/^fix(\([^)]+\))?!?:/'
+  - label: documentation
+    title:
+      - '/^docs(\([^)]+\))?!?:/'
+  - label: dependencies
+    title:
+      - '/^(chore|build)\(deps\):/'
+    branch:
+      - '/^dependabot\//'
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - enhancement
+  patch:
+    labels:
+      - bug
+      - dependencies
+      - documentation
+  default: patch
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,7 +22,12 @@ autolabeler:
     title:
       - '/^\w+(\([^)]+\))?!:/'
     body:
+      # Conventional Commits allows either spelling as the breaking-change
+      # footer token (the spec requires "-" in place of whitespace in
+      # footer tokens generally, with "BREAKING CHANGE" as the one named
+      # exception) — match both so a hyphenated footer isn't missed.
       - '/BREAKING CHANGE:/'
+      - '/BREAKING-CHANGE:/'
   - label: enhancement
     title:
       - '/^feat(\([^)]+\))?!?:/'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -17,9 +17,19 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # Autolabeler is a separate composite action from the root
+      # release-drafter action (see release-drafter/release-drafter's own
+      # autolabeler/README.md) -- it must run as its own step to apply
+      # .github/release-drafter.yml's `autolabeler` rules to this PR.
+      # `issues: write` above is required because it applies labels via
+      # the Issues API (shared by pull requests).
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -26,8 +26,12 @@ jobs:
       # autolabeler/README.md) -- it must run as its own step to apply
       # .github/release-drafter.yml's `autolabeler` rules to this PR.
       # `issues: write` above is required because it applies labels via
-      # the Issues API (shared by pull requests).
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      # the Issues API (shared by pull requests). This job also runs on
+      # `push` (to update the release draft after merge); the autolabeler
+      # action itself throws on any event other than pull_request(_target),
+      # so it must be gated to pull_request events only.
+      - if: github.event_name == 'pull_request'
+        uses: release-drafter/release-drafter/autolabeler@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: release-drafter/release-drafter@v7


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Adds `.github/release-drafter.yml`, which has never existed in this
repository (a ~3-year gap between the `update_release_draft` job, added in
#22, and its required config). Adapted from `kurone-kito/lints-config`'s
current `.github/release-drafter.yml` (fetched fresh at planning time):

- Kept the four existing categories (`enhancement`/`bug`/`documentation`/
  `dependencies`), the `change-template`, `change-title-escapes`, and the
  `## Changes` body template unchanged.
- Added a `💥 Breaking Changes` / `breaking` category, ordered first.
- Switched `name-template` / `tag-template` from the hardcoded
  `v$NEXT_PATCH_VERSION` to `v$RESOLVED_VERSION` so the new
  `version-resolver` actually drives the version.
- Added an `autolabeler` block that derives category labels from
  Conventional-Commit-style PR titles/branches, so a category label no
  longer needs to be applied by hand.
- Added a `version-resolver` block: `major` ← `breaking`, `minor` ←
  `enhancement`, `patch` ← `bug`/`dependencies`/`documentation`,
  `default: patch`.
- Added a comment naming this repository's IDD-reserved labels (`roadmap`,
  `status:authoring`, `status:blocked-by-human`, `status:needs-decision`,
  `idd:ready` — see `docs/idd-policy.md`) that must never be used as
  release-drafter categories or autolabeler targets.

Also creates the `breaking` label (`b60205` — a more saturated/darker red
than the existing `bug` label's `d73a4a`, signaling higher severity; does
not collide with any existing label color).

**Also updates `push-main.yml`** (added after review — see "Update after
review" below): `release-drafter/release-drafter/autolabeler@v7` is a
separate composite action from the root `release-drafter/release-drafter@v7`
drafter action, so it needs its own step for `autolabeler` to actually
apply labels to PRs; `push-main.yml` only ran the drafter step. Added the
autolabeler step (before the drafter step) and `issues: write` on the job
(the autolabeler mutates labels via the Issues API, which pull requests
share).

Closes #52

## Autolabeler regex-to-label evidence

Verified locally with a small Node script against real recent merged PR
titles (`gh pr list --state merged`) plus synthetic examples for the two
label conditions with no real precedent yet in this repo's history:

| PR title (real unless noted) | Matches |
| --- | --- |
| `feat(idd): enable the local worktree guard hooks` | `enhancement` |
| `feat(idd): install the issue-authoring companion skill` | `enhancement` |
| `chore(idd): bump the idd-skill pin to v0.6.0 and reconcile config.json` | *(none — `chore(idd)` isn't a dependency bump)* |
| `ci(idd): add the idd-doctor health gate and the advisory-convergence check` | *(none)* |
| `chore(deps): bump JS-DevTools/npm-publish from 2 to 4` | `dependencies` (title) |
| `chore(deps): bump actions/setup-node from 6 to 7` | `dependencies` (title) |
| `chore(deps-dev): bump typescript from 6.0.3 to 7.0.2` (branch `dependabot/npm_and_yarn/typescript-7.0.2`) | `dependencies` (**branch** match only — the title regex requires literal `chore(deps):`/`build(deps):`, so this real title needs the `dependabot/...` branch fallback; demonstrates why the title-OR-branch design matters, not just in theory) |
| `chore!: bring the modernization branch up to the current pnpm-project-template` (real, #47) | `breaking` (title) |
| `test(idd): verify the completed IDD import against the ONBOARDING Step 6 checklist` | *(none)* |
| *(synthetic)* `feat!: drop support for Node.js 18` | `enhancement` + `breaking` (both — a PR can carry multiple category labels; `version-resolver` still resolves `major` whenever `breaking` is present) |
| *(synthetic)* `fix(api)!: correct off-by-one in date parsing` | `bug` + `breaking` |
| *(synthetic)* `feat(api): add resume export helper` with a Conventional-Commit breaking-change footer in the body (the space-separated form already documented in this repo's `CLAUDE.md` commit rules) | `enhancement` + `breaking` (body match) |
| *(synthetic)* `fix(api): correct pagination cursor handling` with a hyphenated breaking-change footer in the body (the alternate form Conventional Commits also permits) | `bug` + `breaking` (body match) |
| *(synthetic)* `docs(readme): clarify installation steps` | `documentation` |
| *(synthetic)* `fix: correct typo in error message` | `bug` |

This PR's own title/body were checked against the same rules and match none
of the five conditions (no `!`, no breaking-change footer, not a
`chore(deps)`/`build(deps)`/`dependabot/...` change), so it correctly falls
through to the `version-resolver`'s `default: patch`.

**Update after review**: Copilot's review body raised no findings.
CodeRabbit raised three points across a summary comment and an inline
thread:

1. The `breaking` footer regex only matched the space-separated
   Conventional-Commits footer form — genuine gap, fixed in `2a337ad`
   (both accepted spellings of that footer now match, per the
   Conventional Commits spec's footer-token exception; the table above
   reflects this — see the `.github/release-drafter.yml` diff for the
   exact patterns rather than repeating them here, to avoid the very
   self-labeling trap those patterns exist to detect).
2. **The workflow never actually ran the autolabeler.**
   `release-drafter/release-drafter/autolabeler@v7` is a separate
   composite action from the root drafter action
   (`release-drafter/release-drafter@v7`) — confirmed against the
   upstream repo's own `autolabeler/action.yml` and `autolabeler/README.md`
   — and `push-main.yml` only ran the drafter step. This was the correct
   half of CodeRabbit's claim; fixed in `9ecbfa7` by adding the
   autolabeler as its own step (plus `issues: write`, since it applies
   labels via the Issues API). Everything in the evidence table above was
   verified against the regex patterns directly and stays accurate now
   that the step that actually runs them is wired up.
3. My own first-pass reply to point 2 incorrectly investigated a
   different, tangential question — whether `categories[*].label` /
   `version-resolver.*.labels`'s deprecation warnings (unrelated to
   whether autolabeler runs at all) indicated a functional break. They
   don't (confirmed via `parse-categories.ts`'s backward-compatibility
   shim, tracked separately in #81), but that verification didn't
   actually address CodeRabbit's real point about the missing step. Full
   disposition history, including this correction, is in the PR
   comments.

## A note on acceptance criterion 4 (verifying `update_release_draft` succeeds on this PR)

The issue's Background section says release-drafter reads its config from
the default branch, not the PR head — based on the confirmed failure on PR
#51 (run `30687875451`). That run's stack trace shows it executed under
release-drafter **v5** (`.../v5/dist/index.js`); it ran at 06:30 UTC, before
#54 (merged 07:36 UTC the same day) bumped the pin to **v7**, which `main`
has used ever since.

Checking v7.7.0's actual tagged source
(`src/common/config/parse-config-target.ts` @
`34d80673e067bdc0c24568d3af899c216adcfaa9`) shows that when `config-name`
has no explicit `@ref`, it resolves to the workflow run's `context.ref` —
not a hardcoded default branch. For `pull_request` events, `context.ref`
(`GITHUB_REF`) is `refs/pull/<n>/merge`, the synthetic ref that already
includes this PR's own diff merged onto current `main`. So on v7, the job
is expected to find `.github/release-drafter.yml` on this PR's own first
run, once this commit is present — directly observable on this PR's own
checks, matching the acceptance criterion's literal wording.

**Confirmed**: `update_release_draft` passed on this PR's first CI run
(commit `004ee71`), and again after each follow-up fix commit (`2a337ad`,
`9ecbfa7`) — acceptance criterion 4 is satisfied as literally written,
with no separate follow-up push needed beyond this PR's own commits.

## Recommended follow-up issues

- #81 — migrate `.github/release-drafter.yml`'s `categories` /
  `version-resolver` blocks off the deprecated field shapes flagged by
  `update_release_draft`'s own log (see the review-update note above).
  Deliberately deferred: the deprecated fields are still fully functional
  today, and this PR intentionally mirrors `kurone-kito/lints-config`'s
  current (also-deprecated) config shape per the originating issue.

## Validation performed

- `python3 -c "import yaml,json; ..."` — confirms the file parses as valid
  YAML with the expected structure (re-run after each fix commit).
- `actionlint .github/workflows/*.yml` — no findings on every commit,
  including after adding the autolabeler step and `issues: write` to
  `push-main.yml`.
- `pnpm run lint`, `pnpm run build`, `pnpm run test` — all pass on every
  commit.
- `gh label list` — confirms the `breaking` label now exists.
- `gh pr checks 79` — `update_release_draft` passes on every commit's CI
  run (see the acceptance-criterion-4 note above).
