### PR TITLE
test: assert the generated types accept the official JSON Resume sample

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "json2ts -i node_modules/@jsonresume/schema/schema.json -o index.d.ts",
-    "clean": "rimraf -g \"*.d.ts\" \"*.tgz\" \"node_modules/.cache/**/*\"",
+    "clean": "rimraf -g \"*.d.ts\" \"*.tgz\" \"*.tsbuildinfo\" \"node_modules/.cache/**/*\"",
     "lint": "pnpm run --stream \"/lint:check:.+/\"",
     "lint:check:biome": "biome check",
     "lint:check:cspell": "cspell lint --no-progress --show-suggestions -u \"./**/*\"",
@@ -34,7 +34,7 @@
     "lint:fix:markdown": "markdownlint-cli2 --fix \"**/*.md\"",
     "prepack": "npm run -s clean && npm run -s build",
     "prepare": "husky install",
-    "test": "tsc --noEmit",
+    "test": "rimraf -g \"*.tsbuildinfo\" && tsc --noEmit",
     "idd:advisory-convergence": "idd-advisory-convergence",
     "idd:advisory-wait-state": "idd-advisory-wait-state",
     "idd:audit-authored-issue": "idd-audit-authored-issue",

--- a/test/sample-resume.test.mts
+++ b/test/sample-resume.test.mts
@@ -1,0 +1,35 @@
+/**
+ * Compile-time conformance test: type-checks the official JSON Resume
+ * sample against the generated `ResumeSchema`, and asserts that an
+ * obviously wrong shape is rejected instead of silently widening to
+ * `any`.
+ *
+ * This file has no runtime behavior; `pnpm run test` (`tsc --noEmit`)
+ * is the only thing that "runs" it. It must run after `pnpm run
+ * build`, since `../index.d.ts` does not exist in a clean checkout —
+ * see `.github/workflows/push-feature.yml` for that ordering.
+ */
+
+import sample from '@jsonresume/schema/sample.resume.json' with {
+  type: 'json',
+};
+import type { ResumeSchema } from '../index.js';
+
+/**
+ * The schema package's own canonical example must be assignable to the
+ * generated type: this is the property consumers actually depend on.
+ */
+export const resume: ResumeSchema = sample;
+
+/**
+ * A `basics.name` typed as `number` must fail to compile. Keeping the
+ * property on its own line (rather than an object literal one-liner)
+ * keeps `@ts-expect-error` attached to it regardless of how the
+ * surrounding object gets reformatted.
+ */
+export const invalid: ResumeSchema = {
+  basics: {
+    // @ts-expect-error basics.name must be a string, not a number.
+    name: 42,
+  },
+};


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Closes #41

Adds a compile-time conformance test proving the generated `ResumeSchema`
actually accepts the documents it claims to describe, instead of only
proving `index.d.ts` parses.

- `test/sample-resume.test.mts`: type-checks `@jsonresume/schema`'s own
  `sample.resume.json` (read live from the installed package, not a
  copied snapshot) against `ResumeSchema`, plus a negative
  `@ts-expect-error` case on `basics.name: number` so a type that
  silently widened to `any` would be caught. No new runtime test
  framework or dependency — it's picked up by the existing
  `tsconfig.json` `**/*.mts` include and runs under `pnpm run test`
  (`tsc --noEmit`), same as before.
- `package.json`: hardens `test`/`clean` against a stale
  `tsconfig.tsbuildinfo` incremental-cache artifact discovered while
  verifying the test above (see "Corruption check" below for why this
  was necessary, not optional).

## Corruption check (disclosed, per the issue's acceptance criteria)

Ran this by hand before opening the PR — the issue explicitly requires
recording the observation that a deliberately corrupted generated type
makes the test fail, since "a test that cannot fail is not a test."

**First attempt surfaced a real bug, not just confirmation.** This
repo's shared `@kurone-kito/typescript-config` sets `composite: true`,
which makes `tsc --noEmit` write a `tsconfig.tsbuildinfo`
incremental-cache file. After running `pnpm run test` once
successfully, hand-editing `index.d.ts`'s `basics.name` from `string`
to `number` and re-running the *old* `pnpm run test` (`tsc --noEmit`,
no cache clearing) **kept passing** — reproducibly, across repeated
reruns — even though the file's mtime was strictly newer and its
content genuinely differed. Only deleting `tsconfig.tsbuildinfo`
by hand made the same corrupted file correctly fail. CI itself was
never at risk (every run starts from a fresh checkout with no
carried-over cache), but the standard local edit/test loop was: a
schema regeneration that broke the types could silently keep showing
green right after a prior green run.

That's the second commit on this branch (`package.json`): `test` now
clears `*.tsbuildinfo` immediately before every `tsc --noEmit`, and
`clean` removes it too (matching its existing `.gitignore` entry).

**Verification against the shipped script** (plain `pnpm run test`,
no manual cache surgery, run immediately after a prior green pass —
the exact scenario that previously masked the bug):

```console
$ pnpm run build && pnpm run test
$ sed -i '19s/name?: string;/name?: number;/' index.d.ts   # basics.name: string -> number
$ pnpm run test
$ rimraf -g "*.tsbuildinfo" && tsc --noEmit
test/sample-resume.test.mts(22,14): error TS2322: Type '{ ... basics: { name: string; ... } ... }'
  is not assignable to type 'ResumeSchema'.
  The types of 'basics.name' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.
test/sample-resume.test.mts(32,5): error TS2578: Unused '@ts-expect-error' directive.
[ELIFECYCLE] Test failed. See above for more details.
```

Both failures are meaningful: `TS2322` because the positive case
(the real sample) no longer satisfies the corrupted type, and `TS2578`
because the negative case's expected error stopped occurring (`42` is
now a legal `number`) — proving the `@ts-expect-error` line itself
would fail if the type stopped rejecting it, not just that it's
present. `index.d.ts` was then restored with a clean `pnpm run build`
and `pnpm run test` re-confirmed green before pushing.

## Acceptance criteria checklist

- [x] `pnpm run test` fails on a clean checkout with no `index.d.ts`
      (`TS2307: Cannot find module '../index.js'`), and CI
      (`push-feature.yml`) already sequences build → lint → test
      explicitly.
- [x] With the artifact built, `pnpm run test` type-checks
      `sample.resume.json` against `ResumeSchema` and exits `0`.
- [x] Deliberately corrupting the generated type makes the test fail —
      recorded above, including the incremental-cache pitfall found
      and fixed along the way.
- [x] At least one `@ts-expect-error` negative case exists and would
      itself fail (`TS2578`) if the expected error stopped occurring.
- [x] No new runtime test framework added to `devDependencies`.

## Notes

- No `tsconfig.json` change was needed — its `include` already covers
  `./**/*.mts`.
- The `tsconfig.tsbuildinfo` caching gap is specific to this project's
  local dev loop, not this PR's `.mts` file; flagging here in case a
  maintainer wants a narrower upstream report against
  `@kurone-kito/typescript-config` itself, but no further diff is
  proposed here beyond the two-line script hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation coverage using the official JSON Resume sample.
  * Added checks to ensure invalid field values are correctly rejected during type checking.

* **Chores**
  * Improved test cleanup by removing generated build information before validation runs.
  * Updated cleanup behavior to keep the project workspace free of temporary compilation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->