### PR TITLE
test: verification artifact for #42 (not for merge)

### DIFF
--- a/.github/workflows/type-drift.yml
+++ b/.github/workflows/type-drift.yml
@@ -1,0 +1,73 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+name: Detect generated type drift
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  type-drift:
+    name: Diff the generated types against the base branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Stages the pull request merge result
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@v7
+        with:
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
+          node-version-file: .node-version
+      - env:
+          HUSKY: 0
+        name: Install the dependencies (pull request head)
+        run: pnpm install --frozen-lockfile
+      - name: Build the generated types (pull request head)
+        run: pnpm run build
+      - name: Stash the head-side generated types
+        run: mv index.d.ts "$RUNNER_TEMP/head-index.d.ts"
+      - name: Stages the base branch into a scratch directory
+        uses: actions/checkout@v7
+        with:
+          path: base-branch
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+      - env:
+          HUSKY: 0
+        name: Install the dependencies (base branch)
+        run: pnpm install --frozen-lockfile
+        working-directory: base-branch
+      - name: Build the generated types (base branch)
+        run: pnpm run build
+        working-directory: base-branch
+      - name: Diff the generated types and write the job summary
+        run: |
+          set -u
+          base_file="base-branch/index.d.ts"
+          head_file="$RUNNER_TEMP/head-index.d.ts"
+          diff_file="$RUNNER_TEMP/type-drift.diff"
+          diff -u "$base_file" "$head_file" > "$diff_file"
+          status=$?
+          if [ "$status" -eq 0 ]; then
+            # shellcheck disable=SC2016
+            echo 'No type drift detected in `index.d.ts`.' | tee -a "$GITHUB_STEP_SUMMARY"
+          elif [ "$status" -eq 1 ]; then
+            {
+              # shellcheck disable=SC2016
+              echo '## Generated `index.d.ts` type drift'
+              echo
+              echo '```diff'
+              cat "$diff_file"
+              echo '```'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "diff failed with exit status $status (base or head index.d.ts missing or unreadable)" >&2
+            exit 1
+          fi

--- a/.github/workflows/type-drift.yml
+++ b/.github/workflows/type-drift.yml
@@ -53,8 +53,16 @@ jobs:
           base_file="base-branch/index.d.ts"
           head_file="$RUNNER_TEMP/head-index.d.ts"
           diff_file="$RUNNER_TEMP/type-drift.diff"
+          # GitHub Actions runs `run:` steps under `bash -eo pipefail` by
+          # default. `diff` exits 1 whenever the files differ -- the
+          # normal, expected outcome of a real schema bump -- so capturing
+          # its exit status must not trip `set -e`, or the job would fail
+          # on exactly the case it must not. Disable -e for this one
+          # command only (matches the pattern in post-merge-cleanup.yml).
+          set +e
           diff -u "$base_file" "$head_file" > "$diff_file"
           status=$?
+          set -e
           if [ "$status" -eq 0 ]; then
             # shellcheck disable=SC2016
             echo 'No type drift detected in `index.d.ts`.' | tee -a "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@commitlint/cli": "^21.2.0",
     "@commitlint/config-conventional": "^21.2.0",
     "@cspell/cspell-types": "^10.0.1",
-    "@jsonresume/schema": "^1.3.1",
+    "@jsonresume/schema": "^1.0.1",
     "@kurone-kito/biome-config": "^0.23.0-alpha.1",
     "@kurone-kito/commitlint-config": "^0.23.0-alpha.1",
     "@kurone-kito/cspell-config": "^0.23.0-alpha.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       '@jsonresume/schema':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.0.1
+        version: 1.0.1
       '@kurone-kito/biome-config':
         specifier: ^0.23.0-alpha.1
         version: 0.23.0-alpha.1(@biomejs/biome@2.5.6)
@@ -459,8 +459,8 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
-  '@jsonresume/schema@1.3.1':
-    resolution: {integrity: sha512-S9zH1vmS67b1Ld6p9A+sHiZgqZox4lWTVHtca3VarRVkRtp3C/EMQ2bSNlO39+o+0OZbrY+Srnn7Q8uJOtxZhQ==}
+  '@jsonresume/schema@1.0.1':
+    resolution: {integrity: sha512-SK00PVceNPshiTIbXX+Qz2LxycRbIe6Qb+8oUY8+fnxKFYWJqOmIjCoaVYegSmpUyjHxppcIXqzt+Snrc040ww==}
     engines: {node: '>=20'}
 
   '@kurone-kito/biome-config@0.23.0-alpha.1':
@@ -755,6 +755,9 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -1056,9 +1059,6 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  jsonschema@1.5.0:
-    resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
-
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
@@ -1073,6 +1073,14 @@ packages:
     resolution: {integrity: sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==}
     engines: {node: '>=22.22.1'}
     hasBin: true
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1348,6 +1356,10 @@ packages:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
+
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
 
@@ -1378,6 +1390,11 @@ packages:
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  z-schema@4.2.4:
+    resolution: {integrity: sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
 snapshots:
 
@@ -1773,9 +1790,9 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@jsonresume/schema@1.3.1':
+  '@jsonresume/schema@1.0.1':
     dependencies:
-      jsonschema: 1.5.0
+      z-schema: 4.2.4
 
   '@kurone-kito/biome-config@0.23.0-alpha.1(@biomejs/biome@2.5.6)':
     optionalDependencies:
@@ -1952,6 +1969,9 @@ snapshots:
       wrap-ansi: 9.0.0
 
   commander@14.0.3: {}
+
+  commander@2.20.3:
+    optional: true
 
   commander@8.3.0: {}
 
@@ -2252,8 +2272,6 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  jsonschema@1.5.0: {}
-
   katex@0.16.22:
     dependencies:
       commander: 8.3.0
@@ -2271,6 +2289,10 @@ snapshots:
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
+
+  lodash.get@4.4.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash@4.17.21: {}
 
@@ -2650,6 +2672,8 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
+  validator@13.15.35: {}
+
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-uri@3.1.0: {}
@@ -2676,3 +2700,11 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  z-schema@4.2.4:
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.15.35
+    optionalDependencies:
+      commander: 2.20.3


### PR DESCRIPTION
Verification artifact for #42, not intended to merge. Pins `@jsonresume/schema` to `1.0.1` (down from the resolved `1.3.1`) on a Dependabot-style branch name, purely to exercise the new `type-drift.yml` workflow's diff-rendering and `dependabot/*`-branch trigger paths. Will be closed and the branch deleted once the workflow run's evidence is captured. Refs #42.