### PR TITLE
ci: detect generated type drift on dependency updates

### DIFF
--- a/.github/workflows/type-drift.yml
+++ b/.github/workflows/type-drift.yml
@@ -1,0 +1,73 @@
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+name: Detect generated type drift
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  type-drift:
+    name: Diff the generated types against the base branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Stages the pull request merge result
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@v7
+        with:
+          cache: ${{ !env.ACT && 'pnpm' || '' }}
+          node-version-file: .node-version
+      - env:
+          HUSKY: 0
+        name: Install the dependencies (pull request head)
+        run: pnpm install --frozen-lockfile
+      - name: Build the generated types (pull request head)
+        run: pnpm run build
+      - name: Stash the head-side generated types
+        run: mv index.d.ts "$RUNNER_TEMP/head-index.d.ts"
+      - name: Stages the base branch into a scratch directory
+        uses: actions/checkout@v7
+        with:
+          path: base-branch
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+      - env:
+          HUSKY: 0
+        name: Install the dependencies (base branch)
+        run: pnpm install --frozen-lockfile
+        working-directory: base-branch
+      - name: Build the generated types (base branch)
+        run: pnpm run build
+        working-directory: base-branch
+      - name: Diff the generated types and write the job summary
+        run: |
+          set -u
+          base_file="base-branch/index.d.ts"
+          head_file="$RUNNER_TEMP/head-index.d.ts"
+          diff_file="$RUNNER_TEMP/type-drift.diff"
+          diff -u "$base_file" "$head_file" > "$diff_file"
+          status=$?
+          if [ "$status" -eq 0 ]; then
+            # shellcheck disable=SC2016
+            echo 'No type drift detected in `index.d.ts`.' | tee -a "$GITHUB_STEP_SUMMARY"
+          elif [ "$status" -eq 1 ]; then
+            {
+              # shellcheck disable=SC2016
+              echo '## Generated `index.d.ts` type drift'
+              echo
+              echo '```diff'
+              cat "$diff_file"
+              echo '```'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "diff failed with exit status $status (base or head index.d.ts missing or unreadable)" >&2
+            exit 1
+          fi

--- a/.github/workflows/type-drift.yml
+++ b/.github/workflows/type-drift.yml
@@ -53,8 +53,16 @@ jobs:
           base_file="base-branch/index.d.ts"
           head_file="$RUNNER_TEMP/head-index.d.ts"
           diff_file="$RUNNER_TEMP/type-drift.diff"
+          # GitHub Actions runs `run:` steps under `bash -eo pipefail` by
+          # default. `diff` exits 1 whenever the files differ -- the
+          # normal, expected outcome of a real schema bump -- so capturing
+          # its exit status must not trip `set -e`, or the job would fail
+          # on exactly the case it must not. Disable -e for this one
+          # command only (matches the pattern in post-merge-cleanup.yml).
+          set +e
           diff -u "$base_file" "$head_file" > "$diff_file"
           status=$?
+          set -e
           if [ "$status" -eq 0 ]; then
             # shellcheck disable=SC2016
             echo 'No type drift detected in `index.d.ts`.' | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Closes #42

Adds `.github/workflows/type-drift.yml`, a read-only, `pull_request`-triggered
workflow that makes generated `index.d.ts` changes visible without committing
the artifact:

- Generates `index.d.ts` twice in one job -- once from the pull request's
  merge result, once from the base branch checked out into a scratch
  `base-branch/` directory -- then diffs the two.
- Writes the result to the job summary: a fenced unified diff when the types
  differ, or an explicit "no type drift" line when they don't.
- Never fails the job because a difference exists -- a type change is often
  the intended outcome of a schema bump -- but does fail on a genuine tooling
  failure (a missing/unreadable generated file from a broken build), which is
  a different `diff` exit status than "files differ".
- Declares `permissions: contents: read` only, no write scope, no
  comment-posting token.
- Triggers on bare `pull_request:` (no branch filter), so it fires for
  slash-namespaced branches such as `dependabot/*` the same way it does for
  this repository's own `issue/*` branches.

## A real bug caught by the self-review loop

An independent critique-pass subagent found that GitHub Actions runs `run:`
steps under `bash -eo pipefail` by default. `diff` exits `1` whenever the
compared files differ -- the normal, expected "type drift exists" case --
so without guarding it, `set -e` aborted the script right there, before
`status=$?` was ever captured. Net effect: the job would have **failed on
every PR that actually changes the generated types**, exactly the case the
issue requires it not to. Fixed by wrapping the `diff` call in `set +e` /
`set -e`, matching the existing pattern already used in
`.github/workflows/post-merge-cleanup.yml`. Verified locally by replaying the
exact `bash --noprofile --norc -eo pipefail {0}` invocation GitHub Actions
uses, against all three branches (no drift / drift / tooling failure) before
pushing.

## Verification (disclosed, per the issue's acceptance criteria)

The issue requires proving this works, not just asserting it. Two things
needed a real PR to observe (GitHub-rendered job summary, GitHub's own job
conclusion) -- local script replay isn't sufficient evidence for those, so a
temporary, unmerged verification PR was opened and closed after capturing
evidence:

**Verification PR**: [#83](https://github.com/kurone-kito/jsonresume-types/pull/83)
(closed, not merged; branch deleted) from
`dependabot/npm_and_yarn/at-jsonresume/schema-1.0.1` -- based on this branch
(so the new workflow was present), plus one commit pinning
`@jsonresume/schema` down to `1.0.1` (from the resolved `1.3.1`) purely to
produce a real generated-type diff. This single PR exercises both the
schema-diff-rendering criterion and the `dependabot/*`-branch-trigger
criterion at once.

- Local schema-version probe before picking `1.0.1`: `@jsonresume/schema`
  `1.2.1` -> `1.3.1` produces schema.json changes but a **byte-identical**
  generated `index.d.ts` (confirmed with `json2ts` locally) -- worth
  recording on its own, since "the resolved schema version changed" and
  "the generated types changed" are different conditions, which is exactly
  what this workflow disambiguates. `1.0.1` -> `1.3.1` reproduces the three
  hunks this issue's own background section describes.
- Workflow run: [`31665203919`](https://github.com/kurone-kito/jsonresume-types/actions/runs/31665203919),
  job "Diff the generated types against the base branch", triggered via
  `pull_request` on the `dependabot/npm_and_yarn/at-jsonresume/schema-1.0.1`
  branch. **Conclusion: `success`.** Rendered job summary (captured from the
  step log, since job summaries have no REST endpoint):

  ```diff
  ## Generated `index.d.ts` type drift

  --- base-branch/index.d.ts	2026-08-13 03:52:27.166629399 +0000
  +++ /home/runner/work/_temp/head-index.d.ts	2026-08-13 03:52:23.788657392 +0000
  @@ -6,7 +6,7 @@
     */

    /**
  - * Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04
  + * e.g. 2014-06-29
     */
    export type Iso8601 = string;

  @@ -194,7 +194,10 @@
        * e.g. Certified Kubernetes Administrator
        */
       name?: string;
  -    date?: Iso8601;
  +    /**
  +     * e.g. 1989-06-12
  +     */
  +    date?: string;
       /**
        * e.g. http://example.com
        */
  @@ -340,5 +343,4 @@
       lastModified?: string;
       [k: string]: unknown;
     };
  -  [k: string]: unknown;
   }
  ```

  (Diff direction is base=`1.3.1` -> head=`1.0.1`, the reverse of a normal
  upgrade, since the verification pin was a downgrade -- the same three
  hunks as the issue's background section, mirrored.)
- One caveat, stated plainly rather than overclaimed: the branch-name
  simulation proves the `pull_request` **trigger** fires correctly for a
  `dependabot/*`-named branch. It does not exercise Dependabot's own
  restricted-token behavior on a real Dependabot-authored PR -- moot here,
  since this workflow declares `contents: read` and uses no secrets, so a
  restricted token changes nothing about what it needs.
- `git ls-files | grep index.d.ts` on this branch: empty -- the workflow
  never commits the generated artifact.

**This PR's own CI run** (touches no schema-affecting input) independently
demonstrates the "no type drift" explicit-line path:
[run `31665293916`](https://github.com/kurone-kito/jsonresume-types/actions/runs/31665293916/job/94338437140),
conclusion `success`, job summary line: `No type drift detected in
\`index.d.ts\`.`

## Acceptance criteria checklist

- [x] A pull request that changes the resolved `@jsonresume/schema` version
      shows a unified diff of the generated `index.d.ts` in the job summary
      -- verification PR #83.
- [x] A pull request that touches no schema-affecting input shows the
      explicit "no type drift" line -- this PR's own run.
- [x] The job never fails because a difference exists -- verification PR
      #83 concluded `success` with the diff rendered.
- [x] `index.d.ts` is still absent from `git ls-files`.
- [x] The workflow declares `permissions: contents: read` and nothing
      wider.
- [x] The workflow runs on a `dependabot/*` branch's pull request --
      verification PR #83's branch name.

