### PR TITLE
ci: migrate release-drafter.yml off deprecated categories/version-resolver fields

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,15 +7,22 @@ tag-template: v$RESOLVED_VERSION
 # never be added as release-drafter categories or autolabeler targets.
 categories:
   - title: 💥 Breaking Changes
-    label: breaking
+    when:
+      label: breaking
+    semver-increment: major
   - title: 🚀 Features
-    label: enhancement
+    when:
+      label: enhancement
+    semver-increment: minor
   - title: 🐛 Bug Fixes
-    label: bug
+    when:
+      label: bug
   - title: 📝 Documentation
-    label: documentation
+    when:
+      label: documentation
   - title: 🧰 Maintenance
-    label: dependencies
+    when:
+      label: dependencies
     collapse-after: 5
 autolabeler:
   - label: breaking
@@ -42,19 +49,6 @@ autolabeler:
       - '/^(chore|build)\(deps\):/'
     branch:
       - '/^dependabot\//'
-version-resolver:
-  major:
-    labels:
-      - breaking
-  minor:
-    labels:
-      - enhancement
-  patch:
-    labels:
-      - bug
-      - dependencies
-      - documentation
-  default: patch
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 template: |


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Migrates `.github/release-drafter.yml` off the deprecated
`categories[*].label`/`labels` shorthand and the top-level
`version-resolver` block onto the modern `when:` condition plus
per-category `semver-increment` shape (pinned action:
`release-drafter/release-drafter@v7`, currently resolving to v7.7.0;
see [release-drafter/release-drafter#1558](https://github.com/release-drafter/release-drafter/pull/1558)).

- Each category's `label: X` becomes `when: { label: X }`.
- `💥 Breaking Changes` gets `semver-increment: major`, `🚀 Features`
  gets `semver-increment: minor`. `🐛 Bug Fixes`, `📝 Documentation`,
  and `🧰 Maintenance` get no explicit field — the schema default is
  `patch`, matching today's `version-resolver.default: patch`.
- The top-level `version-resolver` block is removed entirely.

Closes #81

## Behavior-preservation verification

Read the pinned `release-drafter@v7.7.0` source directly
(`parse-categories.ts`, `category-matching.ts`,
`resolve-version-increment.ts`) rather than trusting the deprecation
notes alone:

- A category with no explicit `type:` defaults to `type: 'changelog'`.
  None of the 5 migrated categories declare `type: version-resolver`.
- `resolveVersionKeyIncrement` computes `versionResolverPriority =
  getHighestPriority({ categories: getVersionResolverCategories(...) })
  ?? priorityMap.patch`. Since no `type: version-resolver` category
  exists post-migration, this **always** floors at `patch` —
  reproducing today's `version-resolver.default: patch` fallback
  unconditionally.
- `changelogPriority` is computed separately from the same `categories`
  array's own `semver-increment` fields, so a matching
  `breaking`/`enhancement` label still elevates the resolved version to
  `major`/`minor` via `Math.max(changelogPriority, versionResolverPriority)`.
- `categorySchemaDefaults['semver-increment']` is confirmed `'patch'`
  in `config.schema.ts` (`@default "patch"`).

Net effect: the migrated shape is provably equivalent to the current
split `categories`/`version-resolver` config for every label
combination in use today, including the uncategorized-PR fallback.

**Live verification**: `push-main.yml`'s `update_release_draft` job
triggers on `pull_request: [opened, reopened, synchronize]` against
`main`, so this PR's own CI run exercises the exact job the issue's
acceptance criteria describe. Before opening this PR, the draft
release baseline was captured as tag `v0.5.1`, one 📝 Documentation
entry (#85), one collapsed 🧰 Maintenance section (6 entries), rest
uncategorized. Post-run comparison (job log + draft-release diff) will
be posted as a follow-up comment once CI completes.

## Recommended follow-up

None. This closes out the remaining deferred piece of #52.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release categorization to use label-based conditions.
  * Added automatic major and minor version increments for breaking changes and enhancements.
  * Preserved categorization for bug fixes, documentation, and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->