### PR TITLE
chore(idd): reconcile ciGate/advisoryBotLogins config gaps

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -10,6 +10,7 @@
     "heartbeatInterval": "PT12H"
   },
   "trustedMarkerActors": ["kurone-kito"],
+  "advisoryBotLogins": ["coderabbitai[bot]"],
   "workshop": {
     "exampleRepository": ""
   },
@@ -32,6 +33,9 @@
   "advisoryWait": {
     "convergenceScope": "all-prs",
     "exemptBotAuthoredPrs": true
+  },
+  "ciGate": {
+    "trustSourcePinnedRequiredChecks": true
   },
   "autopilotSuitability": {
     "floor": 3

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -263,8 +263,14 @@ pass does not need to re-investigate the same ground:
   pinned to `integration_id: 15368` on the `main` branch-protection
   ruleset, id `20745987`, added after the mid-session migration from
   classic branch protection to GitHub rulesets -- see #75 for the full
-  writeup). The flag itself stays unset (fail-closed default `false`) for
-  this re-import; revisit alongside #75.
+  writeup). The flag itself stayed unset (fail-closed default `false`) at
+  re-import time, pending out-of-band verification of the pinned
+  integration's producer identity. That verification completed and the
+  flag is now set to `true` (#87): `integration_id 15368` is GitHub's own
+  built-in "GitHub Actions" app, and exactly one workflow file in this
+  repository produces the `idd-advisory-convergence` check-run name, so
+  `idd-pre-merge-readiness`/`idd-ci-wait-state` no longer downgrade that
+  check to unresolved (`"source-pinned"`) once it is otherwise passing.
 
 ## IDD Labels
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -270,7 +270,10 @@ pass does not need to re-investigate the same ground:
   built-in "GitHub Actions" app, and exactly one workflow file in this
   repository produces the `idd-advisory-convergence` check-run name, so
   `idd-pre-merge-readiness`/`idd-ci-wait-state` no longer downgrade that
-  check to unresolved (`"source-pinned"`) once it is otherwise passing.
+  check once it is otherwise passing -- each helper's own fail-closed
+  label is unchanged (`unknown` in `idd-pre-merge-readiness`,
+  `"source-pinned"` in `idd-ci-wait-state`); only the downgrade itself
+  stops firing for this check.
 
 ## IDD Labels
 


### PR DESCRIPTION
## Summary

This session's IDD autopilot-loop retrospective surfaced two related, currently unset
configuration gaps in `.github/idd/config.json`, both of which default to fail-closed behavior
per `policy.schema.json`.

- Adds `ciGate.trustSourcePinnedRequiredChecks: true`. Since `main`'s branch protection migrated
  to GitHub Rulesets (#75), the required check `idd-advisory-convergence` is pinned via
  `integration_id: 15368` rather than by plain check name. `idd-pre-merge-readiness`/
  `idd-ci-wait-state` downgrade any `integration_id`-pinned required check to unresolved
  (`"source-pinned"`) regardless of its actual pass/fail state, unless the repository operator
  explicitly opts in after verifying out-of-band that the pinned integration is the sole producer
  of the named required check. `integration_id 15368` is GitHub's own built-in "GitHub Actions"
  app (not a third-party integration), and exactly one workflow file in this repository
  (`.github/workflows/idd-advisory-convergence.yml`) produces a check-run under that name.
- Adds `advisoryBotLogins: ["coderabbitai[bot]"]`. Per `policy.schema.json`, an absent
  `advisoryBotLogins` list disables the classification (fail-closed) of an advisory review bot's
  post-disposition acknowledgement comments as structurally ack-only. This repository's advisory
  review bot is CodeRabbit; its actual GitHub login on this repository was confirmed as
  `coderabbitai[bot]`.

Both fields are additive; every existing key in `.github/idd/config.json` is unchanged.

**Bootstrapping nuance**: because the opt-in only takes effect once it is present in the merged
config, this PR's own merge-readiness evaluation may still show `idd-advisory-convergence` as
`source-pinned` against its own head (the old config is what is live until merge). That is
expected and does not block this PR under this repository's existing "discard helper output when
it disagrees with independently verified live state" override policy (`docs/idd-policy.md`). The
fix should be observable end to end starting with the next PR merged after this one.

## Verification

- `pnpm run idd:doctor --strict` shows `PASS .github/idd/config.json validates against
  policy.schema.json`, with the same 4 pre-existing WARNs as an unmodified `main` checkout
  (post-merge cleanup backlog, release-tag drift, branch-protection-not-readable, and a
  worktree-guard/hooksPath note) — no new warnings introduced by this change.
- `pnpm run lint && pnpm run build && pnpm run test` — all pass.
- Live facts backing the `ciGate` opt-in were re-verified against this repository before drafting
  the plan: `integration_id 15368` resolves to GitHub's own "GitHub Actions" app on the latest
  merged PR's check-runs, exactly one workflow file produces the `idd-advisory-convergence` check
  name, and the ruleset's required-check pin/strict-policy match (`{"matches": true,
  "strict": true}`).
- Two independent critique passes (`general-purpose` subagent) reviewed the plan and the diff; the
  plan pass found the originally drafted commit subject exceeded the 72-character limit, fixed
  before committing. The diff pass reported no issues.

Closes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated review and CI safeguards by recognizing advisory bot activity and requiring trusted sources for pinned checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->