### PR TITLE
chore(idd): opt in to ciGate.trustEmptyProtectionReads

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -35,7 +35,8 @@
     "exemptBotAuthoredPrs": true
   },
   "ciGate": {
-    "trustSourcePinnedRequiredChecks": true
+    "trustSourcePinnedRequiredChecks": true,
+    "trustEmptyProtectionReads": true
   },
   "autopilotSuitability": {
     "floor": 3

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -274,6 +274,29 @@ pass does not need to re-investigate the same ground:
   label is unchanged (`unknown` in `idd-pre-merge-readiness`,
   `"source-pinned"` in `idd-ci-wait-state`); only the downgrade itself
   stops firing for this check.
+- **`ciGate.trustEmptyProtectionReads`** -- evaluated: the classic
+  branch-protection endpoint
+  (`GET /repos/{owner}/{repo}/branches/main/protection`) has 404d with
+  the specific body `"Branch not protected"` since `main`'s protection
+  migrated from classic protection to the ruleset described above (see
+  #75). Per this repository's fail-closed default, that ambiguous `404`
+  blocked `idd-pre-merge-readiness`/`idd-merge-execute`'s own
+  required-check read on every PR since the migration (confirmed live on
+  #88's own merge-readiness evaluation, which needed a manual
+  live-state override), reporting `cannot determine required checks:
+  protection/ruleset unreadable` even when the actual required check was
+  independently confirmed green. Out-of-band verification completed
+  (#89): the `404` body is the genuine-absence shape, not a generic
+  not-found; and the same automation token successfully reads the
+  comparably-or-more-sensitive Rulesets endpoints
+  (`rulesets/20745987`, `rules/branches/main`) for the same branch, with
+  no permission-masking pattern observed anywhere. The flag is now set to
+  `true`: `idd-pre-merge-readiness`/`idd-merge-execute` no longer fail
+  closed on this specific `404` shape. This is independent of
+  `trustSourcePinnedRequiredChecks` above -- that flag trusts a *named,
+  present* required check's producer identity, while this one trusts a
+  `404` read itself as genuinely-empty protection/ruleset configuration
+  rather than a masked permission failure.
 
 ## IDD Labels
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -276,23 +276,30 @@ pass does not need to re-investigate the same ground:
   stops firing for this check.
 - **`ciGate.trustEmptyProtectionReads`** -- evaluated: the classic
   branch-protection endpoint
-  (`GET /repos/{owner}/{repo}/branches/main/protection`) has 404d with
-  the specific body `"Branch not protected"` since `main`'s protection
-  migrated from classic protection to the ruleset described above (see
-  #75). Per this repository's fail-closed default, that ambiguous `404`
-  blocked `idd-pre-merge-readiness`/`idd-merge-execute`'s own
-  required-check read on every PR since the migration (confirmed live on
-  #88's own merge-readiness evaluation, which needed a manual
-  live-state override), reporting `cannot determine required checks:
-  protection/ruleset unreadable` even when the actual required check was
-  independently confirmed green. Out-of-band verification completed
-  (#89): the `404` body is the genuine-absence shape, not a generic
-  not-found; and the same automation token successfully reads the
-  comparably-or-more-sensitive Rulesets endpoints
-  (`rulesets/20745987`, `rules/branches/main`) for the same branch, with
-  no permission-masking pattern observed anywhere. The flag is now set to
-  `true`: `idd-pre-merge-readiness`/`idd-merge-execute` no longer fail
-  closed on this specific `404` shape. This is independent of
+  (`GET /repos/{owner}/{repo}/branches/main/protection`) has been
+  returning `404` with the specific body `"Branch not protected"` since
+  `main`'s protection migrated from classic protection to the ruleset
+  described above (see #75). Per this repository's fail-closed default,
+  that ambiguous `404` blocked `idd-pre-merge-readiness`/
+  `idd-merge-execute`'s own required-check read on every PR since the
+  migration (confirmed live on #88's own merge-readiness evaluation,
+  which needed a manual live-state override), reporting `cannot
+  determine required checks: protection/ruleset unreadable` even when
+  the actual required check was independently confirmed green.
+  Out-of-band verification completed (#89): the `404` body is the
+  genuine-absence shape, not a generic not-found; and the same
+  automation token successfully reads the comparably-or-more-sensitive
+  Rulesets endpoints (`rulesets/20745987`, `rules/branches/main`) for the
+  same branch, with no permission-masking pattern observed anywhere. The
+  flag is now set to `true`: per `fetchGovernanceJson`'s implementation
+  (`idd-skill`'s `pre-merge-readiness.mjs`), the opt-in trusts **any**
+  `404` -- regardless of response body -- from **all three** governance
+  reads (`rules/branches/{base}`, each matched ruleset detail, and the
+  classic `branches/{base}/protection` endpoint) as a genuinely-empty
+  result, not narrowly the classic endpoint's exact observed shape; the
+  verified `"Branch not protected"` response above is the
+  repository-specific evidence that justified enabling this broader
+  opt-in, not the boundary of what it trusts. This is independent of
   `trustSourcePinnedRequiredChecks` above -- that flag trusts a *named,
   present* required check's producer identity, while this one trusts a
   `404` read itself as genuinely-empty protection/ruleset configuration


### PR DESCRIPTION
## Summary

Add `ciGate.trustEmptyProtectionReads: true` to `.github/idd/config.json`'s
existing `ciGate` object, additive alongside
`trustSourcePinnedRequiredChecks: true` (added by #87/#88). Document the
opt-in in `docs/idd-policy.md`'s "v0.6.0 Re-import Notes" section,
mirroring the existing sibling bullet.

## Why

`main`'s branch protection migrated from classic protection to a GitHub
Ruleset (#75), so the classic `branches/main/protection` endpoint now
permanently 404s with `"Branch not protected"`. Under the fail-closed
default, that ambiguous 404 made `idd-pre-merge-readiness`/
`idd-merge-execute` report `cannot determine required checks:
protection/ruleset unreadable` on every PR since the migration (confirmed
on PR #88's own merge-readiness evaluation, which needed a manual
live-state override), even when the actual required check was
independently confirmed green.

Out-of-band verification (recorded in #89): the 404 body is the
genuine-absence shape, not a generic not-found, and the same automation
token successfully reads the comparably-sensitive Rulesets endpoints for
the same branch, with no permission-masking pattern observed.

This is config-only and additive; no other repository behavior changes.

Closes #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated CI gate behavior to trust empty protection-read responses while preserving existing required-check validation.

* **Documentation**
  * Added a v0.6.0 policy note documenting the evaluation and enablement of this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->