### PR TITLE
ci(release): migrate to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,12 @@ on:
       - published
 permissions:
   contents: read
+  id-token: write
   packages: write
 jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
-    env:
-      INVALID_DUMMY_TOKEN: invalid-token
     steps:
       - name: Stages the pushed branch
         uses: actions/checkout@v7
@@ -22,20 +21,19 @@ jobs:
       - name: Prepare the Node.js environment
         uses: actions/setup-node@v7
         with:
-          cache: ${{ !env.ACT && 'pnpm' || '' }}
+          cache: pnpm
           node-version-file: .node-version
       - name: Resolve the dependencies
         run: pnpm install --frozen-lockfile
       - name: Build and release for NPM
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          access: public
-          dry-run: ${{ !!env.ACT }}
-          token: ${{ !env.ACT && secrets.NPM_TOKEN || env.INVALID_DUMMY_TOKEN }}
+        run: pnpm publish --access public --no-git-checks
+      - name: Set up the .npmrc for the GitHub Packages registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat << EOF > "${HOME}/.npmrc"
+          @kurone-kito:registry=https://npm.pkg.github.com/
+          //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+          EOF
       - name: Build and release for GitHub Registry
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          access: public
-          dry-run: ${{ !!env.ACT }}
-          registry: https://npm.pkg.github.com
-          token: ${{ !env.ACT && secrets.GITHUB_TOKEN || env.INVALID_DUMMY_TOKEN }}
+        run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/jsonresume-types/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Migrates `.github/workflows/release.yml` from the token-based
`JS-DevTools/npm-publish@v4` action to native `pnpm publish`, now that
this repository is registered as an npm trusted publisher (#40:
workflow filename `release.yml`, no environment).

- Adds `id-token: write` to the `deploy` job's permissions so the
  npmjs.org publish step authenticates via short-lived OIDC instead of
  `secrets.NPM_TOKEN`, picking up automatic provenance attestation as a
  side effect (no explicit `--provenance` flag needed at the pinned
  `pnpm@11.15.1`).
- Replaces both `JS-DevTools/npm-publish@v4` steps with native
  `pnpm publish --access public --no-git-checks` calls. The GitHub
  Packages step keeps authenticating with `secrets.GITHUB_TOKEN`,
  now via a scoped `.npmrc` written just before that publish step.
- Removes the `INVALID_DUMMY_TOKEN` / `env.ACT` dry-run scaffolding,
  which existed only to make the old token-based path testable locally
  via `act`; OIDC cannot be simulated by `act`, so it has no equivalent
  replacement.

Closes #44

## Non-goals (explicitly out of scope, per the issue)

- No `common-release.yml` reusable-workflow split — this repository has
  no second trigger that would reuse the publish logic, and splitting
  would risk invalidating #40's trusted-publisher registration, which
  is keyed on the exact `release.yml` filename.
- No prerelease/`next`-tag publish path or `@kurone-kito/is-prerelease`
  dependency — this repository has never published a prerelease.
- `NPM_TOKEN` repository secret removal — deferred to #45, only after a
  real OIDC publish has succeeded.

## Test plan

This is a GitHub Actions workflow change with no way to exercise a live
publish outside of an actual `release` event, so validation is limited
to what's checkable pre-merge:

- [x] `pnpm run lint` (biome / cspell / markdownlint) passes
- [x] `pnpm run build` and `pnpm run test` pass (unaffected by this
      change, run per repository policy)
- [x] Manual line-by-line re-read of the resulting YAML against the
      issue's acceptance criteria (`id-token: write` present, no
      remaining `JS-DevTools/npm-publish` or `secrets.NPM_TOKEN`
      reference, GitHub Packages step still authenticates with
      `GITHUB_TOKEN`, filename unchanged)
- [ ] Live OIDC publish and provenance-attestation verification —
      deferred to #45 (the actual release), not verifiable here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package release and publishing workflow.
  * Enhanced publishing reliability and authentication for supported package registries.
  * Streamlined dependency caching during automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->