### PR TITLE
test: verify #43 required status check blocks a lint-breaking PR

### DIFF
--- a/VERIFY_LINT_BREAK.ts
+++ b/VERIFY_LINT_BREAK.ts
@@ -1,0 +1,1 @@
+export const badlyFormatted    =1;


### PR DESCRIPTION
Throwaway verification PR for #43 — intentionally breaks lint to confirm the newly-added `required_status_checks` entries on Ruleset `20745987` actually block merge. Will be closed (not merged) once verified. Not an IDD claim branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a formatting verification fixture for linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->