### PR TITLE
fix: resolve 14 open Dependabot alerts via a scoped pnpm update

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,8 +898,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1030,8 +1030,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.2.2:
@@ -1074,8 +1074,8 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
@@ -1224,13 +1224,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -1385,7 +1381,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -1903,7 +1899,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1984,7 +1980,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 7.0.2
@@ -2127,15 +2123,15 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.0.6: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.4.6(picomatch@4.0.2):
+  fdir@6.4.6(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.2
+      picomatch: 4.0.5
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -2224,7 +2220,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2240,8 +2236,8 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.17
       is-glob: 4.0.3
-      js-yaml: 4.1.0
-      lodash: 4.17.21
+      js-yaml: 4.3.1
+      lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.5.3
       tinyglobby: 0.2.14
@@ -2272,7 +2268,7 @@ snapshots:
     optionalDependencies:
       yaml: 2.9.0
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   lru-cache@11.1.0: {}
 
@@ -2496,7 +2492,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   minimatch@10.2.6:
     dependencies:
@@ -2540,9 +2536,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.2: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
 
@@ -2609,8 +2603,8 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.4.6(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves the 14 open Dependabot alerts (8 high, 6 moderate) currently
reported against `pnpm-lock.yaml`. All 14 trace to four
transitively-resolved devDependencies whose locked versions predate
patches already permitted by their own parents' declared semver
ranges:

| Package     | Locked (vulnerable) | Resolved (patched) |
| ----------- | -------------------- | ------------------- |
| `fast-uri`  | `3.0.6`              | `3.1.5`              |
| `js-yaml`   | `4.1.0`               | `4.3.1` (plus the pre-existing unaffected `5.2.2` instance from `markdownlint-cli2`, untouched) |
| `lodash`    | `4.17.21`            | `4.18.1`             |
| `picomatch` | `2.3.1` and `4.0.2`  | `2.3.2` and `4.0.5`  |

This ran exactly `pnpm update fast-uri js-yaml lodash picomatch` (no
blanket `pnpm update`) — a lockfile-only diff. `package.json` is
untouched, and no `@kurone-kito/*-config` package is affected.

Resolves #93

## Verification

- `git diff --stat main` shows exactly one changed file:
  `pnpm-lock.yaml`.
- `pnpm why fast-uri` → only `3.1.5`.
- `pnpm why js-yaml` → every instance `>= 4.1.1` (`4.3.1` and the
  pre-existing `5.2.2`).
- `pnpm why lodash` → only `4.18.1`.
- `pnpm why picomatch` → `2.3.2` (2.x line) and `4.0.5` (4.x line).
- `pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass
  unchanged.

## Post-merge Dependabot re-scan (informational only)

At PR-open time, `gh api repos/kurone-kito/jsonresume-types/dependabot/alerts
--paginate --jq '[.[] | select(.state=="open")] | length'` still
reports **14** open alerts. GitHub's Dependabot re-scan runs
asynchronously and may lag the merge, so this count is expected to
trend toward 0 once the scan catches up after this PR merges — not a
merge-blocking check.
